### PR TITLE
Create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- Please remove the line that does not fit. -->
+<!-- Please also enter the respective issue ID after the #. -->
+<!-- E.g.: This issue closes #1. -->
+This issue closes #\<issue-id>.
+This issue is part of #\<issue-id>.
+
+<!-- Please include a summary of the changes and the related issue. -->
+<!-- Please also include relevant motivation and context. -->
+
+## How can this be tested?
+
+<!-- Please describe the manual tests that you ran to verify your changes. -->
+<!-- Provide instructions so we can reproduce. --> 
+
+## Screenshots
+
+<!-- If you made changes to the frontend, please add screenshots here. -->
+<!-- Ideally make before and after screenshots. -->
+<!-- Don't forget to add descriptions to the screenshots. -->
+
+<!-- If no UI changes were made, please state that here. -->
+
+## Checklist
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have lowered the linter errors. Before: \<NUMBER>. After: \<NUMBER>
+


### PR DESCRIPTION
This PR adds a request template to improve clarity and ensure all necessary information is provided.

After this PR is merged, the pull request description box will automatically be populated with the template for every new PR. Contributors can then fill out the gaps in the template themselves.

A lot of markdown code is commented out so contributors just have to add things. That's why the markdown preview is quite empty.