### PR TITLE
Add `pull_request_target` to CI triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
 
 jobs:   
   lint:


### PR DESCRIPTION
Fixes a bug where we (as in repo admins) cannot approve workflow runs.
