### PR TITLE
Vitest should now work properly

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "dev": "vite",
     "typecheck": "tsc --noEmit",
     "build": "npm run typecheck && vite build",
-    "test":"vitest run tests/dummy.test.ts --reporter=verbose",
+    "test":"vitest run --reporter=verbose",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/client/src/components/Administration/ProjectAdmin.tsx
+++ b/client/src/components/Administration/ProjectAdmin.tsx
@@ -81,7 +81,7 @@ const ProjectAdmin: React.FC = () => {
 
   /* Helper method for fetching all projects of a course */
   const getProjectsForCourse = (course: string): Promise<Project[]> => {
-    return get(`courseProject?projectGroupName=${course}`)
+    return get(`courseProject?courseName=${course}`)
       .then(projects => projects.map((project: { id: string; projectName: string; studentsCanJoinProject: boolean; }) => ({
         id: project.id,
         projectName: project.projectName,
@@ -102,11 +102,11 @@ const ProjectAdmin: React.FC = () => {
         const coursesData = await get("course");
 
         const coursesWithProjects: Course[] = await Promise.all(
-          coursesData.map(async (course: { projectGroupName: string; semester: string; studentsCanCreateProject: boolean; }) => {
-            const projects = await getProjectsForCourse(course.projectGroupName);
+          coursesData.map(async (course: { courseName: string; semester: string; studentsCanCreateProject: boolean; }) => {
+            const projects = await getProjectsForCourse(course.courseName);
             return {
               semester: course.semester,
-              courseName: course.projectGroupName,
+              courseName: course.courseName,
               projects: projects,
               studentsCanCreateProject: course?.studentsCanCreateProject || false,
             };
@@ -125,7 +125,7 @@ const ProjectAdmin: React.FC = () => {
 
   /* Method for creating a course */
   const handleCreateCourse = async (semester: string, courseName: string,) => {
-    const body: { [key: string]: string } = { semester, projectGroupName: courseName };
+    const body: { [key: string]: string } = { semester, courseName: courseName };
 
     const data = await post("course", body).catch((error) => {
       console.error("Error fetching data:", error.message);
@@ -142,7 +142,7 @@ const ProjectAdmin: React.FC = () => {
   const handleCreateProject = async (projectName: string) => {
     if (!selectedCourse) return;
 
-    const body: { [key: string]: string } = { semester: selectedCourse.semester, projectGroupName: selectedCourse.courseName, projectName };
+    const body: { [key: string]: string } = { semester: selectedCourse.semester, courseName: selectedCourse.courseName, projectName };
 
     const data = await post("courseProject", body).catch((error) => {
       console.error("Error fetching data:", error.message);
@@ -160,9 +160,9 @@ const ProjectAdmin: React.FC = () => {
     if (!selectedCourse || !selectedProject) return;
 
     const body: { [key: string]: string } = {
-      projectGroupName: selectedCourse.courseName,
-      newSemester: selectedCourse.semester,
-      newProjectGroupName: courseName,
+      courseName: selectedCourse.courseName,
+      newSemester: selectedCourse.semester, // ToDo remove
+      newCourseName: courseName,
       projectName: selectedProject.projectName,
       newProjectName: projectName,
     };
@@ -183,9 +183,9 @@ const ProjectAdmin: React.FC = () => {
     if (!selectedCourse) return;
 
     const body: { [key: string]: string | boolean } = {
-      projectGroupName: selectedCourse.courseName,
+      courseName: selectedCourse.courseName,
       newSemester: editedCourse.semester,
-      newProjectGroupName: editedCourse.courseName,
+      newCourseName: editedCourse.courseName,
       studentsCanCreateProject: editedCourse.studentsCanCreateProject,
     };
 

--- a/client/src/components/Administration/UserAdmin.tsx
+++ b/client/src/components/Administration/UserAdmin.tsx
@@ -43,7 +43,7 @@ function UserEdit({ user, onClose }: { user: User; onClose: (update: boolean) =>
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ "email": user.email, "newGithubUsername": githubUsername })
+                    body: JSON.stringify({ "userEmail": user.email, "newGithubUsername": githubUsername })
                 })
                 .then(checkError)
                 .catch(console.error));
@@ -53,7 +53,7 @@ function UserEdit({ user, onClose }: { user: User; onClose: (update: boolean) =>
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ "email": user.email, "status": status })
+                    body: JSON.stringify({ "userEmail": user.email, "status": status })
                 })
                 .then(checkError)
                 .catch(console.error));
@@ -63,7 +63,7 @@ function UserEdit({ user, onClose }: { user: User; onClose: (update: boolean) =>
                 {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
-                    body: JSON.stringify({ "email": user.email, "password": password })
+                    body: JSON.stringify({ "userEmail": user.email, "password": password })
                 })
                 .then(checkError)
                 .catch(console.error));
@@ -166,7 +166,7 @@ const UserAdmin = () => {
         fetch(`/user/confirmation/trigger`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email }),
+          body: JSON.stringify({ userEmail: user.email }),
         })
           .then(checkError)
           .catch(console.error);

--- a/client/src/components/Configuration/CourseParticipation.tsx
+++ b/client/src/components/Configuration/CourseParticipation.tsx
@@ -25,7 +25,7 @@ const CourseParticipation: React.FC = () => {
   type Project = {
     id: number; 
     projectName: string; 
-    projectGroupName: string;
+    courseName: string;
   };
   
   const navigate = useNavigate();
@@ -43,14 +43,14 @@ const CourseParticipation: React.FC = () => {
     email: string;
   } | null>(null);
 
-  const [projectGroups, setProjectGroups] = useState<string[]>([]);
+  const [courses, setCourses] = useState<string[]>([]);
   const [userProjects, setUserProjects] = useState<string[]>([]);
 
   const [enrolledProjects, setEnrolledProjects] = useState<Project[]>([]);
-  const [selectedEnrolledProjectGroup, setSelectedEnrolledProjectGroup] = useState<string>("");
+  const [selectedEnrolledCourse, setSelectedEnrolledCourse] = useState<string>("");
 
   const [availableProjects, setAvailableProjects] = useState<Project[]>([]);
-  const [selectedAvailableProjectGroup, setSelectedAvailableProjectGroup] = useState<string>("");
+  const [selectedAvailableCourse, setSelectedAvailableCourse] = useState<string>("");
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -68,11 +68,11 @@ const CourseParticipation: React.FC = () => {
 
     fetchUserData();
 
-    const fetchProjectGroups = async () => {
+    const fetchCourses = async () => {
       try {
         const response = await fetch("http://localhost:3000/course");
         const data = await response.json();
-        setProjectGroups(data.map((item: Project) => item.projectGroupName));
+        setCourses(data.map((item: Project) => item.courseName));
         console.log("Fetched project groups:", data);
       } catch (error: unknown) {
         if (error instanceof Error) {
@@ -81,7 +81,7 @@ const CourseParticipation: React.FC = () => {
       }
     };
 
-    fetchProjectGroups();
+    fetchCourses();
 
     const fetchUserProjects = async() => {
       try {
@@ -102,16 +102,16 @@ const CourseParticipation: React.FC = () => {
 
   useEffect(() => {
     const fetchEnrolledProjects = async () => {
-      if (selectedEnrolledProjectGroup) {
+      if (selectedEnrolledCourse) {
         try {
           const response = await fetch(
-            `http://localhost:3000/courseProject?projectGroupName=${selectedEnrolledProjectGroup}`
+            `http://localhost:3000/courseProject?courseName=${selectedEnrolledCourse}`
           );
           const data = await response.json();
           const mappedProjects = data.map((item: Project) => ({
             id: item.id,
             projectName: item.projectName,
-            projectGroupName: item.projectGroupName || selectedEnrolledProjectGroup,
+            courseName: item.courseName || selectedEnrolledCourse,
           }));
 
           const enrolledProjects = mappedProjects.filter((item: Project) => userProjects.includes(item.projectName));
@@ -128,24 +128,24 @@ const CourseParticipation: React.FC = () => {
     };
 
     fetchEnrolledProjects();
-  }, [selectedEnrolledProjectGroup]);
+  }, [selectedEnrolledCourse]);
 
   const filteredEnrolledProjects = enrolledProjects.filter(
-    (project) => project.projectGroupName === selectedEnrolledProjectGroup
+    (project) => project.courseName === selectedEnrolledCourse
   );
 
   useEffect(() => {
     const fetchAvailableProjects = async () => {
-      if (selectedAvailableProjectGroup) {
+      if (selectedAvailableCourse) {
         try {
           const response = await fetch(
-            `http://localhost:3000/courseProject?projectGroupName=${selectedAvailableProjectGroup}`
+            `http://localhost:3000/courseProject?courseName=${selectedAvailableCourse}`
           );
           const data = await response.json();
           const mappedProjects = data.map((item: Project) => ({
             id: item.id,
             projectName: item.projectName,
-            projectGroupName: item.projectGroupName || selectedAvailableProjectGroup,
+            courseName: item.courseName || selectedAvailableCourse,
           }));
 
           const availableProjectsWithoutEnrolled = mappedProjects.filter((item: Project) => !userProjects.includes(item.projectName));
@@ -162,10 +162,10 @@ const CourseParticipation: React.FC = () => {
     };
 
     fetchAvailableProjects();
-  }, [selectedAvailableProjectGroup]);
+  }, [selectedAvailableCourse]);
 
   const filteredAvailableProjects = availableProjects.filter(
-    (project: Project) => project.projectGroupName === selectedAvailableProjectGroup
+    (project: Project) => project.courseName === selectedAvailableCourse
   );
 
   const handleJoin = async (projectName: string) => {
@@ -176,9 +176,8 @@ const CourseParticipation: React.FC = () => {
 
     const body = {
       projectName,
-      memberName: user.name,
-      memberRole: role,
-      memberEmail: user.email,
+      userEmail: user.email,
+      role: role,
     };
 
     try {
@@ -218,7 +217,7 @@ const CourseParticipation: React.FC = () => {
 
     const body = {
       projectName,
-      memberEmail: user.email,
+      userEmail: user.email,
     };
 
     try {
@@ -263,14 +262,14 @@ const CourseParticipation: React.FC = () => {
           <div className="SelectWrapper">
             <Select
               onValueChange={(value) => {
-                setSelectedEnrolledProjectGroup(value);
+                setSelectedEnrolledCourse(value);
               }}
             >
               <SelectTrigger className="SelectTrigger">
                 <SelectValue placeholder="Select a project group" />
               </SelectTrigger>
               <SelectContent className="SelectContent">
-                {projectGroups.map((group, index) => (
+                {courses.map((group, index) => (
                   <SelectItem key={index} value={group}>
                     {group}
                   </SelectItem>
@@ -322,14 +321,14 @@ const CourseParticipation: React.FC = () => {
           <div className="SelectWrapper">
             <Select
               onValueChange={(value) => {
-                setSelectedAvailableProjectGroup(value);
+                setSelectedAvailableCourse(value);
               }}
             >
               <SelectTrigger className="SelectTrigger">
                 <SelectValue placeholder="Select a project group" />
               </SelectTrigger>
               <SelectContent className="SelectContent">
-                {projectGroups.map((group, index) => (
+                {courses.map((group, index) => (
                   <SelectItem key={index} value={group}>
                     {group}
                   </SelectItem>

--- a/client/src/components/Configuration/ProjectConfig.tsx
+++ b/client/src/components/Configuration/ProjectConfig.tsx
@@ -77,7 +77,7 @@ const ProjectConfig: React.FC = () => {
             `http://localhost:3000/user/courses?userEmail=${userEmail}`
           );
           const data = await response.json();
-          setCourses(data.map((course: { projectGroupName: string }) => course.projectGroupName));
+          setCourses(data.map((course: { courseName: string }) => course.courseName));
         } catch (error) {
           console.error("Error fetching courses:", error);
         }
@@ -186,9 +186,9 @@ const ProjectConfig: React.FC = () => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            email: userEmail,
+            userEmail: userEmail,
             URL: newURL,
-            project: selectedProject,
+            projectName: selectedProject,
           }),
         });
         const data = await response.json();
@@ -216,9 +216,8 @@ const ProjectConfig: React.FC = () => {
 
     const body = {
       projectName,
-      memberName: user.name,
-      memberRole: role,
-      memberEmail: user.email,
+      userEmail: user.email,
+      role: role,
     };
 
     try {
@@ -257,7 +256,7 @@ const ProjectConfig: React.FC = () => {
     }
     const body = {
       projectName,
-      memberEmail: user.email,
+      userEmail: user.email,
     };
 
     try {
@@ -290,7 +289,7 @@ const ProjectConfig: React.FC = () => {
 
   const handleCreate = async (projectName: string) => {
     const body = {
-      projectGroupName: selectedCourse,
+      courseName: selectedCourse,
       projectName,
     };
 

--- a/client/src/components/Configuration/Settings.tsx
+++ b/client/src/components/Configuration/Settings.tsx
@@ -116,7 +116,7 @@ const Settings: React.FC = () => {
     }
 
     const body = {
-      email: user.email,
+      userEmail: user.email,
       password: newPassword,
     };
 

--- a/client/src/components/Configuration/UserPanel.tsx
+++ b/client/src/components/Configuration/UserPanel.tsx
@@ -118,7 +118,7 @@ const UserPanel: React.FC = () => {
     }
 
     const body = {
-      email: user.email,
+      userEmail: user.email,
       password: newPassword,
     };
     try {
@@ -159,7 +159,7 @@ const UserPanel: React.FC = () => {
     }
   
     const body = {
-      email: user?.email,
+      userEmail: user?.email,
       newGithubUsername: githubUsername,
     };
     let msg = document.getElementById('ErrorMessageGithub');

--- a/client/src/components/Projects/CodeActivity.tsx
+++ b/client/src/components/Projects/CodeActivity.tsx
@@ -37,8 +37,8 @@ const CodeActivity: React.FC = () => {
     githubUsername: string;
   } | null>(null);
   // @ts-ignore: suppress unused variable warning
-  const [projectGroups, setProjectGroups] = useState<string[]>([]);
-  const [selectedProjectGroup, setSelectedProjectGroup] = useState<string>("");
+  const [courses, setCourses] = useState<string[]>([]);
+  const [selectedCourse, setSelectedCourse] = useState<string>("");
   const [commitsPerSprint, setCommitsPerSprint] = useState<any[]>([]);
 
   const handleNavigation = () => {
@@ -57,7 +57,7 @@ const CodeActivity: React.FC = () => {
   }, [location.state]);
 
   useEffect(() => {
-    const fetchProjectGroup = async () => {
+    const fetchCourse = async () => {
       if (!projectName) return;
 
       try {
@@ -70,8 +70,8 @@ const CodeActivity: React.FC = () => {
           const text = await response.text();
           if (text) {
             const data = JSON.parse(text);
-            if (data && data.projectGroupName) {
-              setSelectedProjectGroup(data.projectGroupName);
+            if (data && data.courseName) {
+              setSelectedCourse(data.courseName);
             }
           } else {
             console.error("Empty response body");
@@ -84,7 +84,7 @@ const CodeActivity: React.FC = () => {
       }
     };
 
-    fetchProjectGroup();
+    fetchCourse();
   }, [projectName]);
 
   useEffect(() => {
@@ -121,7 +121,7 @@ const CodeActivity: React.FC = () => {
 
     try {
       const response = await fetch(
-        `http://localhost:3000/user/user/projects?email=${encodeURIComponent(
+        `http://localhost:3000/user/projects?userEmail=${encodeURIComponent(
           user.email
         )}&projectName=${encodeURIComponent(projectName)}`
       );
@@ -151,12 +151,12 @@ const CodeActivity: React.FC = () => {
 
   useEffect(() => {
     const fetchAllSprints = async () => {
-      if (!selectedProjectGroup) return;
-
+      if (!selectedCourse) return;
+  
       try {
         const response = await fetch(
-          `http://localhost:3000/sprints?projectGroupName=${encodeURIComponent(
-            selectedProjectGroup
+          `http://localhost:3000/sprints?courseName=${encodeURIComponent(
+            selectedCourse
           )}`
         );
         const fetchedSprints = await response.json();
@@ -185,7 +185,8 @@ const CodeActivity: React.FC = () => {
     };
 
     fetchAllSprints();
-  }, [selectedProjectGroup]);
+  }, [selectedCourse]);
+  
 
   const getCommits = async (page: number) => {
     if (!repoDetails || !sprints.length) {

--- a/client/src/components/Projects/Happiness.tsx
+++ b/client/src/components/Projects/Happiness.tsx
@@ -35,8 +35,8 @@ const Happiness: React.FC = (): React.ReactNode => {
     null
   );
   const [activeTab, setActiveTab] = useState("User");
-  const [projectGroups, setProjectGroups] = useState<string[]>([]);
-  const [selectedProjectGroup, setSelectedProjectGroup] = useState<string>("");
+  const [courses, setCourses] = useState<string[]>([]);
+  const [selectedCourse, setSelectedCourse] = useState<string>("");
   const [values, setValues] = useState<DateObject[]>([]);
   const [happiness, setHappiness] = useState<number>(0);
   const [happinessData, setHappinessData] = useState<any[]>([]);
@@ -61,11 +61,11 @@ const Happiness: React.FC = (): React.ReactNode => {
   }, [location.state]);
 
   useEffect(() => {
-    const fetchProjectGroups = async () => {
+    const fetchCourses = async () => {
       try {
         const response = await fetch("http://localhost:3000/course");
         const data = await response.json();
-        setProjectGroups(data.map((item: any) => item.projectGroupName));
+        setCourses(data.map((item: any) => item.CourseName));
         console.log("Fetched project groups:", data);
       } catch (error: unknown) {
         if (error instanceof Error) {
@@ -73,7 +73,7 @@ const Happiness: React.FC = (): React.ReactNode => {
         }
       }
     };
-    fetchProjectGroups();
+    fetchCourses();
   }, []);
 
   useEffect(() => {
@@ -92,12 +92,12 @@ const Happiness: React.FC = (): React.ReactNode => {
 
   useEffect(() => {
     const fetchAllSprints = async () => {
-      if (!selectedProjectGroup) return;
+      if (!selectedCourse) return;
 
       try {
         const response = await fetch(
-          `http://localhost:3000/courseProject/sprints?projectGroupName=${encodeURIComponent(
-            selectedProjectGroup
+          `http://localhost:3000/courseProject/sprints?courseName=${encodeURIComponent(
+            selectedCourse
           )}`
         );
         const sprints = await response.json();
@@ -114,7 +114,7 @@ const Happiness: React.FC = (): React.ReactNode => {
     };
 
     fetchAllSprints();
-  }, [selectedProjectGroup]);
+  }, [selectedCourse]);
 
   useEffect(() => {
     const fetchCurrentSprints = async () => {
@@ -161,7 +161,7 @@ const Happiness: React.FC = (): React.ReactNode => {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            projectGroupName: selectedProjectGroup,
+            courseName: selectedCourse,
             dates: formattedDates,
           }),
         }
@@ -226,9 +226,8 @@ const Happiness: React.FC = (): React.ReactNode => {
     ...new Set(happinessData.map((data) => data.userEmail)),
   ];
   uniqueEmails.forEach((email, index) => {
-    emailColors[email] = `hsl(${
-      (index * 360) / uniqueEmails.length
-    }, 100%, 50%)`;
+    emailColors[email] = `hsl(${(index * 360) / uniqueEmails.length
+      }, 100%, 50%)`;
   });
 
   const formattedData: { [sprintName: string]: any } = {};
@@ -278,7 +277,7 @@ const Happiness: React.FC = (): React.ReactNode => {
               <Select
                 onValueChange={(value) => {
                   console.log("Selected Project Group:", value);
-                  setSelectedProjectGroup(value);
+                  setSelectedCourse(value);
                 }}
               >
                 <SelectTrigger className="SelectTrigger">
@@ -288,7 +287,7 @@ const Happiness: React.FC = (): React.ReactNode => {
                   />
                 </SelectTrigger>
                 <SelectContent className="SelectContent">
-                  {projectGroups.map((group) => (
+                  {courses.map((group) => (
                     <SelectItem key={group} value={group}>
                       {group}
                     </SelectItem>

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon --watch src --ext .ts,.js --exec \"npm run build && node dist/server.js\"",
     "build": "tsc",
-    "test":"vitest run tests/semester.test.ts --reporter=verbose",
+    "test":"vitest run --reporter=verbose",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/server/src/CourseManager.ts
+++ b/server/src/CourseManager.ts
@@ -1,0 +1,41 @@
+import { Database } from "sqlite";
+import { ObjectHandler } from "./ObjectHandler";
+import { DatabaseSerializableFactory } from "./Serializer/DatabaseSerializableFactory";
+import { Course } from "./Models/Course";
+import { CourseProject } from "./Models/CourseProject";
+import { DatabaseResultSetReader } from "./Serializer/DatabaseResultSetReader";
+
+
+export class CourseManager {
+  protected db: Database;
+  protected oh: ObjectHandler;
+
+  constructor(db: Database) {
+    this.db = db;
+    this.oh = new ObjectHandler();
+  }
+
+  public async createCourse(): Promise<Course> {
+    const dbsf = new DatabaseSerializableFactory(this.db);
+    const proj = await dbsf.create("Course") as Course;
+    return proj;
+  }
+
+  public async getProjectsForCourse(course: Course): Promise<CourseProject[]> {
+    const projectRows = await this.db.all(`
+            SELECT *
+            FROM projects
+            WHERE courseId = ?
+        `, course.getId());
+    let projects: CourseProject[] = [];
+    for (const row of projectRows) {
+      const project = await this.oh.getCourseProject(row.id, this.db);
+      if (project !== null) {
+        project.setCourse(course);
+        projects.push(project);
+      }
+    }
+
+    return projects;
+  }
+}

--- a/server/src/Models/Admin.ts
+++ b/server/src/Models/Admin.ts
@@ -1,7 +1,7 @@
 import { User } from './User'
 
 export class Admin extends User {
-    constructor() {
-        super();
+    constructor(id: number) {
+        super(id);
     }
 }

--- a/server/src/Models/Course.ts
+++ b/server/src/Models/Course.ts
@@ -1,10 +1,48 @@
-export class Course {
-    getUserCourses() {
-        // Implementation here
-        return [];
-    }
+import { Reader } from "../Serializer/Reader";
+import { Serializable } from "../Serializer/Serializable";
+import { Writer } from "../Serializer/Writer";
 
-    testEcho(str: string): string {
-        return str;
-    }
+export class Course implements Serializable {
+  protected id: number;
+  protected name: string | null = null;
+  protected semester: string | null = null;
+
+  constructor(id: number) {
+    this.id = id;
+  }
+
+  readFrom(reader: Reader): void {
+    this.id = reader.readNumber("id") as number;
+    this.name = reader.readString("courseName");
+    this.semester = reader.readString("semester");
+  }
+
+  writeTo(writer: Writer): void {
+    writer.writeNumber("id", this.id);
+    writer.writeString("courseName", this.name);
+    writer.writeString("semester", this.semester);
+  }
+
+  // Getters
+  public getId(): number {
+    return this.id;
+  }
+
+  public getName(): string | null{
+    return this.name;
+  }
+
+  public getSemester(): string | null {
+    return this.semester;
+  }
+
+
+  // Setters
+  public setName(name: string | null) {
+    this.name = name;
+  }
+
+  public setSemester(semester: string | null) {
+    this.semester = semester;
+  }
 }

--- a/server/src/Models/CourseProject.ts
+++ b/server/src/Models/CourseProject.ts
@@ -1,10 +1,51 @@
-export class CourseProject {
+import { Reader } from "../Serializer/Reader";
+import { Serializable } from "../Serializer/Serializable";
+import { Writer } from "../Serializer/Writer";
+import { Course } from "./Course";
 
-    public userEmail: string = "";
-    public projectName: string = "";
-    public url: string = "";
 
-    constructor() {
-        // dummy course project for set impl
+export class CourseProject implements Serializable {
+  protected id: number;
+  protected name: string | null = null;
+  protected course: Course | null = null;
+
+  constructor(id: number) {
+    this.id = id;
+  }
+
+  async readFrom(reader: Reader): Promise<void> {
+    this.id = reader.readNumber("id") as number;
+    this.name = reader.readString("projectName");
+    this.course = (await reader.readObject("courseId", "Course")) as Course ;
+  }
+  writeTo(writer: Writer): void {
+    writer.writeNumber("id", this.id);
+    writer.writeString("projectName", this.name);
+    writer.writeObject<Course>("courseId", this.course);
+  }
+
+  // Getters
+  public getId(): number {
+    return this.id;
+  }
+
+  public getName(): string | null {
+    return this.name;
+  }
+
+  public getCourse(): Course | null {
+    if (this.course) {
+      return this.course;
     }
+    return null;
+  }
+
+  // Setters
+  public setName(name: string | null) {
+    this.name = name;
+  }
+
+  public setCourse(course: Course | null): void {
+    this.course = course;
+  }
 }

--- a/server/src/Models/DatabaseManager.ts
+++ b/server/src/Models/DatabaseManager.ts
@@ -1,0 +1,48 @@
+import { Database } from "sqlite";
+
+export class DatabaseManager {
+    static async getCourseIdFromName(db: Database, courseName: string): Promise<number> {
+        const courseIdObj = await db.get(`SELECT id
+            FROM courses
+            WHERE courses.courseName = ?`, [courseName]);
+        if (courseIdObj === undefined) {
+        throw new Error("Unknown Course Name!");
+        }
+        const courseId = courseIdObj.id;
+        return courseId;
+    }
+
+    static async getProjectIdFromName(db: Database, projectName: string): Promise<number> {
+        const projectIdObj = await db.get(`SELECT id
+            FROM projects
+            WHERE projects.projectName = ?`, [projectName]);
+        if (projectIdObj === undefined) {
+        throw new Error("Unknown Course Name!");
+        }
+        const projectId = projectIdObj.id;
+        return projectId;
+    }
+
+
+    static async getUserIdFromName(db: Database, userName: string): Promise<number> {
+        const userIdObj = await db.get(`SELECT id
+            FROM users
+            WHERE users.name = ?`, [userName]);
+        if (userIdObj === undefined) {
+        throw new Error("Unknown Course Name!");
+        }
+        const userId = userIdObj.id;
+        return userId;
+    }
+
+    static async getUserIdFromEmail(db: Database, userEmail: string): Promise<number> {
+        const userIdObj = await db.get(`SELECT id
+            FROM users
+            WHERE users.email = ?`, [userEmail]);
+        if (userIdObj === undefined) {
+        throw new Error("Unknown Course Name!");
+        }
+        const userId = userIdObj.id;
+        return userId;
+    }
+}

--- a/server/src/Models/ProjectMember.ts
+++ b/server/src/Models/ProjectMember.ts
@@ -1,0 +1,23 @@
+import { User } from "./User";
+
+
+export class ProjectMember {
+    constructor(
+        protected readonly user: User,
+        protected readonly role: string | null = null,
+        protected readonly userProjectUrl: string | null = null,
+    ) { }
+
+    public getUser(): User {
+        return this.user;
+    }
+
+    public getRole(): string | null {
+        return this.role;
+    }
+
+    public getUrl(): string | null {
+        return this.userProjectUrl;
+    }
+
+}

--- a/server/src/Models/ProjectParticipation.ts
+++ b/server/src/Models/ProjectParticipation.ts
@@ -1,0 +1,23 @@
+import { CourseProject } from "./CourseProject";
+
+
+export class ProjectParticipation {
+    constructor(
+        protected readonly project: CourseProject,
+        protected readonly role: string | null = null,
+        protected readonly userProjectUrl: string | null = null,
+    ) { }
+    
+
+    public getProject(): CourseProject {
+        return this.project;
+    }
+
+    public getRole(): string | null {
+        return this.role;
+    }
+
+    public getUrl(): string | null {
+        return this.userProjectUrl;
+    }
+}

--- a/server/src/Models/User.ts
+++ b/server/src/Models/User.ts
@@ -1,38 +1,72 @@
 import { Visitor } from "./Visitor";
 import { CourseProject } from "./CourseProject";
+import { Serializable } from "../Serializer/Serializable";
+import { Reader } from "../Serializer/Reader";
+import { Writer } from "../Serializer/Writer";
 
-export class User extends Visitor {
-
-  constructor(
-    protected id: number = 0,
-    protected name: string = "",
-    protected githubUsername: string = "",
-    protected email: string = "",
-    protected status: string = "",
-    protected password: string = "",
-    protected resetPasswordToken: string = "",
-    protected resetPasswordExpire: number = 0,
-    protected confirmEmailToken: string = "",
-    protected confirmEmailExpire: number = 0,
-    protected projectsUserIsMemberOf: CourseProject[] = []
-  ) {
+export class User extends Visitor implements Serializable {
+  protected id: number;
+  protected name: string | null = null;
+  protected githubUsername: string | null = null;
+  protected email: string | null = null;
+  protected status: string = "unconfirmed";
+  protected password: string | null = null;
+  protected resetPasswordToken: string | null = null;
+  protected resetPasswordExpire: number | null = null;
+  protected confirmEmailToken: string | null = null;
+  protected confirmEmailExpire: number | null = null;
+  
+  /** Do not call this constructor directly. Instead use the SerializableFactory
+   *  appropriate for your backend!
+   *  example:
+   *    const dsf = new DatabaseSerializableFactory(db); 
+   *    u: User = dsf.create("User");
+   */
+  constructor(id: number) {
     super();
+    this.id = id;
+  }
+
+  readFrom(reader: Reader): void {
+    this.id = reader.readNumber("id") as number;
+    this.name = reader.readString("name");
+    this.githubUsername = reader.readString("githubUsername");
+    this.email = reader.readString("email");
+    this.status = reader.readString("status") as string;
+    this.password = reader.readString("password");
+    this.resetPasswordToken = reader.readString("resetPasswordToken");
+    this.resetPasswordExpire = reader.readNumber("resetPasswordExpire");
+    this.confirmEmailToken = reader.readString("confirmEmailToken");
+    this.confirmEmailExpire = reader.readNumber("confirmEmailExpire");
+  }
+
+  writeTo(writer: Writer): void {
+    writer.writeNumber("id", this.id);
+    writer.writeString("name", this.name);
+    writer.writeString("githubUsername", this.githubUsername);
+    writer.writeString("email", this.email);
+    writer.writeString("status", this.status);
+    writer.writeString("password", this.password);
+    writer.writeString("resetPasswordToken", this.resetPasswordToken);
+    writer.writeNumber("resetPasswordExpire", this.resetPasswordExpire);
+    writer.writeString("confirmEmailToken", this.confirmEmailToken);
+    writer.writeNumber("confirmEmailExpire", this.confirmEmailExpire);
   }
 
   // Getters
-  public getId(): number {
+  public getId(): number | undefined{
     return this.id;
   }
 
-  public getName(): string {
+  public getName(): string | null {
     return this.name;
   }
 
-  public getGithubUsername(): string {
+  public getGithubUsername(): string | null {
     return this.githubUsername;
   }
 
-  public getEmail(): string {
+  public getEmail(): string | null {
     return this.email;
   }
 
@@ -40,44 +74,36 @@ export class User extends Visitor {
     return this.status;
   }
 
-  public getPassword(): string {
+  public getPassword(): string | null{
     return this.password;
   }
 
-  public getResetPasswordToken(): string {
+  public getResetPasswordToken(): string | null{
     return this.resetPasswordToken;
   }
 
-  public getResetPasswordExpire(): number {
+  public getResetPasswordExpire(): number | null {
     return this.resetPasswordExpire;
   }
 
-  public getConfirmEmailToken(): string {
+  public getConfirmEmailToken(): string | null {
     return this.confirmEmailToken;
   }
 
-  public getConfirmEmailExpire(): number {
+  public getConfirmEmailExpire(): number | null {
     return this.confirmEmailExpire;
   }
 
-  public getProjectsMemberIn(): CourseProject[] {
-    return this.projectsUserIsMemberOf;
-  }
-
   // Setters
-  public setId(id: number) {
-    this.id = id;
-  }
-
-  public setName(name: string) {
+  public setName(name: string | null){
     this.name = name;
   }
 
-  public setGithubUsername(githubUsername: string) {
+  public setGithubUsername(githubUsername: string | null){
     this.githubUsername = githubUsername;
   }
 
-  public setEmail(email: string) {
+  public setEmail(email: string | null){
     this.email = email;
   }
 
@@ -85,37 +111,23 @@ export class User extends Visitor {
     this.status = status;
   }
 
-  public setPassword(password: string) {
+  public setPassword(password: string | null){
     this.password = password;
   }
 
-  public setResetPasswordToken(resetPasswordToken: string) {
+  public setResetPasswordToken(resetPasswordToken: string | null){
     this.resetPasswordToken = resetPasswordToken;
   }
 
-  public setResetPasswordExpire(resetPasswordExpire: number) {
+  public setResetPasswordExpire(resetPasswordExpire: number | null){
     this.resetPasswordExpire = resetPasswordExpire;
   }
 
-  public setConfirmEmailToken(confirmEmailToken: string) {
+  public setConfirmEmailToken(confirmEmailToken: string | null){
     this.confirmEmailToken = confirmEmailToken;
   }
 
-  public setConfirmEmailExpire(confirmEmailExpire: number) {
+  public setConfirmEmailExpire(confirmEmailExpire: number | null){
     this.confirmEmailExpire = confirmEmailExpire;
-  }
-
-  public setProjectsMemberIn(projectsUserIsMemberOf: CourseProject[]) {
-    this.projectsUserIsMemberOf = projectsUserIsMemberOf;
-  }
-
-  // Command
-
-  public addProject(project: CourseProject) {
-    this.projectsUserIsMemberOf.push(project)
-  }
-
-  public removeProject(project: CourseProject) {
-    this.projectsUserIsMemberOf = this.projectsUserIsMemberOf.filter(projectEl => projectEl.projectName != project.projectName);
   }
 }

--- a/server/src/ObjectHandler.ts
+++ b/server/src/ObjectHandler.ts
@@ -4,10 +4,10 @@ import { User } from "./Models/User";
 import { CourseProject } from "./Models/CourseProject";
 import { CourseSchedule } from "./Models/CourseSchedule";
 import { Course } from "./Models/Course";
+import { DatabaseResultSetReader } from "./Serializer/DatabaseResultSetReader";
+import { Serializable } from "./Serializer/Serializable";
 
 export class ObjectHandler { 
-
-
 
     public async invokeOnUser(functionName: string, req: Request, res: Response, db: Database): Promise<void> {
         const userEmail = req.body.userEmail;
@@ -78,13 +78,18 @@ export class ObjectHandler {
         }
     }
 
+    public async getUserCount(db: Database): Promise<number | undefined> {
+        return (await db.get('SELECT COUNT(*) AS count FROM users')).count;
+    }
 
-    public async getUser(id: string, db: Database): Promise<User | null> {
+
+    public async getUser(id: number, db: Database): Promise<User | null> {
         const userRow = await db.get('SELECT * FROM users WHERE id = ?', [id]);
         if (!userRow) {
             return null;
         }
-        return new User(userRow.name); // fill user object with data from row, e.g. userRow.id;
+        // Creates a User instance and fills it with attribute values.
+        return (new DatabaseResultSetReader(userRow, db)).readRoot<User>(User) as Promise<User>; 
     }
 
     public async getUserByMail(email: string, db: Database): Promise<User | null> {
@@ -92,18 +97,20 @@ export class ObjectHandler {
         if (!userRow) {
             return null;
         }
-        return new User(userRow.name); // fill user object with data from row, e.g. userRow.id;
+        // Creates a User instance and fills it with attribute values.
+        return (new DatabaseResultSetReader(userRow, db)).readRoot<User>(User) as Promise<User>; 
     }
 
-    public async getCourseProject(id: string, db: Database): Promise<CourseProject | null> {
-        const projectRow = await db.get('SELECT * FROM project WHERE id = ?', [id]);
+    public async getCourseProject(id: number, db: Database): Promise<CourseProject | null> {
+        const projectRow = await db.get('SELECT * FROM projects WHERE id = ?', [id]);
         if (!projectRow) {
             return null;
         }
-        return new CourseProject(); // fill project object with data from row, e.g. projectRow.id;
+        // Creates a CourseProject instance and fills it with attribute values.
+        return (new DatabaseResultSetReader(projectRow, db)).readRoot<CourseProject>(CourseProject) as Promise<CourseProject>; 
     }
 
-    public async getCourseSchedule(id: string, db: Database): Promise<CourseSchedule | null> {
+    public async getCourseSchedule(id: number, db: Database): Promise<CourseSchedule | null> {
         const scheduleRow = await db.get('SELECT * FROM schedules WHERE id = ?', [id]);
         if (!scheduleRow) {
             return null;
@@ -111,13 +118,25 @@ export class ObjectHandler {
         return new CourseSchedule(); // fill schedule object with data from row, e.g. scheduleRow.id;
     }
 
-    public async getCourse(id: string, db: Database): Promise<Course | null> {
-        const courseRow = await db.get('SELECT * FROM projectGroup WHERE id = ?', [id]);
+    public async getCourse(id: number, db: Database): Promise<Course | null> {
+        const courseRow = await db.get('SELECT * FROM courses WHERE id = ?', [id]);
         if (!courseRow) {
             return null;
         }
-        return new Course(); // fill course object with data from row, e.g. courseRow.id;
+        // Creates a Course instance and fills it with attribute values.
+        return (new DatabaseResultSetReader(courseRow, db)).readRoot<Course>(Course) as Promise<Course>; 
     }
 
-    
+    async getSerializableFromId(id: number, className: string, db: Database): Promise<Serializable | null> {
+        switch (className) {
+            case "User":
+                return this.getUser(id, db);
+            case "Course":
+                return this.getCourse(id, db);
+            case "CourseProject":
+                return this.getCourseProject(id, db);
+            default:
+                return null;
+        }
+    }
 }

--- a/server/src/ProjectManager.ts
+++ b/server/src/ProjectManager.ts
@@ -1,0 +1,140 @@
+import { Database } from "sqlite";
+import { User } from "./Models/User";
+import { CourseProject } from "./Models/CourseProject";
+import { ObjectHandler } from "./ObjectHandler";
+import { ProjectParticipation } from "./Models/ProjectParticipation";
+import { ProjectMember } from "./Models/ProjectMember";
+import { DatabaseSerializableFactory } from "./Serializer/DatabaseSerializableFactory";
+
+
+/**
+ * This class manages the n:m relation between CourseProject and User. 
+ * Serializing this is a nightmare, so we are using a direct approach querying the db.
+ * Please treat all outputs of this classes methods as readonly immutables.
+ * Only use the setter and command methods to change the relation!
+ */
+export class ProjectManager {
+    protected db: Database;
+    protected oh: ObjectHandler;
+
+    constructor (db: Database) {
+        this.db = db;
+        this.oh = new ObjectHandler();
+    }
+
+    public async createProject (): Promise<CourseProject> {
+        const dbsf = new DatabaseSerializableFactory(this.db);
+        const proj = await dbsf.create("CourseProject") as CourseProject;
+        return proj;
+    }
+
+    public async getProjectParticipations (user: User):  Promise<ProjectParticipation[]> {
+        const userProjects = await this.db.all(`
+            SELECT projectId, role, url
+            FROM user_projects
+            WHERE userId = ?
+        `, user.getId());
+        let projParts = new Array<ProjectParticipation>;
+        userProjects.forEach(async (row) => {
+            const proj = await this.oh.getCourseProject(row.projectId, this.db);
+            if (proj == null ) {
+                return;
+            }
+            projParts.push(new ProjectParticipation(proj, row.role, row.url));
+        });
+        return projParts;
+    }
+
+    public async getProjectMembers (project: CourseProject): Promise<ProjectMember[]>{
+        const userProjects = await this.db.all(`
+            SELECT userId, role, url
+            FROM user_projects
+            WHERE projectId = ?
+        `, project.getId());
+        let projMems = new Array<ProjectMember>;
+        userProjects.forEach(async (row) => {
+            const user = await this.oh.getUser(row.userId, this.db);
+            if (user == null ) {
+                return;
+            }
+            projMems.push(new ProjectMember(user, row.role, row.url));
+        });
+        return projMems;
+    }
+
+    public async isMemberIn(user: User, project: CourseProject): Promise<Boolean> {
+        const userProject = await this.db.get(`
+            SELECT * 
+            FROM user_projects
+            WHERE userId = ? AND projectId = ?
+        `, [user.getId(), project.getId()]);
+        if (!userProject) {
+            return false;
+        }
+        return true;
+    }
+
+    public async joinProject (user: User, project: CourseProject, role: string | null = null, url: string | null = null) {
+        if (!await this.isMemberIn(user, project)) {
+            await this.db.run(`
+                INSERT INTO user_projects (userId, projectId, role, url)
+                VALUES (?, ?, ?, ?)  
+            `, [user.getId(), project.getId(), role, url]);
+        }
+    }
+
+    public async leaveProject (user: User, project: CourseProject) {
+        if (await this.isMemberIn(user, project)) {
+            await this.db.run(`
+                DELETE FROM user_projects
+                WHERE userId = ? AND projectId = ?}
+            `, [user.getId(), project.getId()]);
+        }
+    }
+
+    public async getRoleIn(user: User, project: CourseProject): Promise<string | null>{
+        const userProjects = await this.db.get(`
+            SELECT role
+            FROM user_projects
+            WHERE userId = ? AND projectId = ?
+        `, [user.getId(), project.getId()]);
+        if (!userProjects){
+            throw new Error("No Course participation found!");
+        }
+        return userProjects.role;
+    }
+
+    public async setRoleIn(user: User, project: CourseProject, role: string | null) {
+        if (!await this.isMemberIn(user, project)){
+            throw new Error("No Course participation found!");
+        }
+        await this.db.run(`
+            UPDATE user_projects
+            SET role = ?
+            WHERE userId = ? AND projectId = ?
+        `, [role, user.getId(), project.getId()]);
+    }
+    
+    public async getUserProjectUrl(user: User, project: CourseProject): Promise<string | null> {
+        const userProjects = await this.db.get(`
+            SELECT url
+            FROM user_projects
+            WHERE userId = ? AND projectId = ?
+        `, [user.getId(), project.getId()]);
+        if (!userProjects){
+            throw new Error("No Course participation found!");
+        }
+        return userProjects.url;
+    }
+
+    public async setUserProjectUrl(user: User, project: CourseProject, url: string | null) {
+        if (!await this.isMemberIn(user, project)){
+            throw new Error("No Course participation found!");
+        }
+        await this.db.run(`
+            UPDATE user_projects
+            SET url = ?
+            WHERE userId = ? AND projectId = ?
+        `, [url, user.getId(), project.getId()]);
+    }
+}

--- a/server/src/Serializer/DatabaseResultSetReader.ts
+++ b/server/src/Serializer/DatabaseResultSetReader.ts
@@ -1,0 +1,117 @@
+import { Serializable } from "./Serializable";
+import { Reader } from "./Reader";
+import { ObjectHandler } from "../ObjectHandler";
+import { Database } from "sqlite";
+
+/**
+ * Reader Class
+ * 
+ * Reads/Writes Serializable Entities to SQLite Database
+ * 
+ */
+export class DatabaseResultSetReader implements Reader {
+    protected attributes: {[attributeName: string]: string | number | null} = {};
+    protected resultSet: Promise<any> | Promise<any[]>;
+    protected db: Database;
+
+    protected wasHandled: Map<{className: string, id: number}, {instance: Serializable}> = new Map();
+
+    
+    constructor(resultSet: Promise<any> | Promise<any[]>, db: Database) {
+        this.resultSet = resultSet;
+        this.db = db;
+    }
+
+    async readRoot<T extends Serializable> (
+        Constructor: new (...args: any[]) => T
+    ): Promise<T | T[]> {
+        this.wasHandled = new Map();
+        // await resultSet
+        const result = await this.resultSet;
+        // either read all or read single row
+        if (Array.isArray(result)) {
+            return await this.readAll(result, Constructor);
+        } else { // Read single row:
+            return await this.readRow<T>(result, Constructor);
+        }
+    }
+
+    readAll<T extends Serializable> (
+        result: any[], Constructor: new (...args: any[]) => T
+    ): T[] {
+        let arr: T[] = [];
+        result.forEach(async (row: any) => {
+            arr.push(await this.readRow<T>(row, Constructor));
+        });
+        return arr;
+    }
+
+    async readRow<T extends Serializable> (
+        row: any, Constructor: new (...args: any[]) => T
+    ): Promise<T> {
+        // Reset attributes dict
+        this.attributes = {};
+        // Read all attributes
+        for (const attribute in row) {
+            const value = row[attribute];
+            // Some type checks
+            if (value !== undefined && 
+                (typeof value === 'string' || typeof value === 'number' || value === null)) {
+                this.attributes[attribute] = value;
+            }
+        }
+        // Create new instance
+        let s: T;
+        // Checking if this table had an id entry.
+        if ("id" in this.attributes) {
+            s = new Constructor(this.attributes["id"]);
+        } else {
+            s = new Constructor();
+        }
+        // Read all attributes into new instance
+        await s.readFrom(this);
+        return s;
+    }
+
+    async readObject(attributeName: string, className: string): Promise<Serializable | null> {
+        // Assuming Object to be id-referenced:
+        const id = this.attributes[attributeName];
+        if (typeof id !== 'number') {
+            throw new Error("Error during Serialization: Id " + attributeName + " is not a number!");
+        }
+        // Check if Object was read already:
+        if (this.wasHandled.has({className: className, id: id})) {
+            console.log("Found a "+ className+" with id "+ id +" in wasHandled.");
+            const o = this.wasHandled.get({className: className, id: id})?.instance;
+            if (o !== undefined) {
+                return o;
+            }
+        }
+        // if not handled yet, create a new Instance and add to wasHandled.
+        const oh = new ObjectHandler();
+        const obj = await oh.getSerializableFromId(id, className, this.db);
+        console.log("Tried to get a "+ className +" with id "+ id +" from db. Result: "+ JSON.stringify(obj));
+        if (obj === null) {
+            return obj;
+        }
+        this.wasHandled.set({className: className, id: id}, {instance: obj});
+        console.log("returning obj to instance.");
+        return obj;
+    }
+
+    readString(attributeName: string): string | null{
+        const val = this.attributes[attributeName];
+        if (val !== null && typeof val !== 'string' ) {
+            throw new Error("Error during Serialization: Attribute " + attributeName + " is not a string! (type of val is " + typeof val +").\nAttributes is: "+ JSON.stringify(this.attributes));  
+        }
+        return val;
+    }
+    readNumber(attributeName: string): number | null {
+        const val = this.attributes[attributeName];
+        if (val !== null && typeof val !== 'number') {
+            throw new Error("Error during Serialization: Attribute " + attributeName + " is not a number!");
+        }
+        return val;
+    }
+     
+}

--- a/server/src/Serializer/DatabaseSerializableFactory.ts
+++ b/server/src/Serializer/DatabaseSerializableFactory.ts
@@ -1,0 +1,90 @@
+import { Serializable } from "../Serializer/Serializable";
+import { SerializableFactory } from "../Serializer/SerializableFactory";
+import { Database } from "sqlite";
+import { User } from "../Models/User";
+import { DatabaseWriter } from "./DatabaseWriter";
+import { CourseProject } from "../Models/CourseProject";
+import { Course } from "../Models/Course";
+
+/**
+ * Factory for creating Serializables in a way specific to the sqlite database.
+ */
+export class DatabaseSerializableFactory implements SerializableFactory {
+    protected db: Database;
+
+    constructor(db: Database) {
+        this.db = db;
+    }
+
+    async create(className: string): Promise<Serializable> {
+        /** @todo extend for all classes. */
+        if (className === "User") {
+            return await this.createEntityIn(User, "users");
+        } else if (className === "CourseProject") {
+            return await this.createEntityIn(CourseProject, "projects");
+        } else if (className === "Course") {
+            return await this.createEntityIn(Course, "courses");
+        } else {
+            throw new Error("Serializable Creation Failed: Unknown class name: " + className);
+        }
+    }
+    
+    /** 
+     * Creates a new Serializable entity and its corresponding database entity.
+     * Will overwrite the Databases Default Values with any defaults from 
+     * entitys class and its constructor!
+     * @param EntityClass Class/constructor for the entity (e.g. User).
+     * @param tableName Name of the Table to add the entity to.
+     */
+    protected async createEntityIn<T extends User | CourseProject | Course>(
+        EntityClass: new (id: number) => T, tableName: string
+    ): Promise<T> {
+        // Create new entity row 
+        const runResult = await this.db.run(`INSERT INTO ${tableName} DEFAULT VALUES`);
+        if (!runResult || runResult.lastID === undefined) {  
+            throw new Error("Serializable Creation Failed: Failed to create db entry for new entity!");
+        }
+ 
+        const e = new EntityClass(runResult.lastID);
+        e.writeTo(new DatabaseWriter(this.db));
+        return e;
+    }
+
+
+    /** 
+     * Creates a new User object and its corresponding database entity.
+     * Will overwrite the Databases Default Values with any defaults from 
+     * User class and its constructor!
+     */
+    /* protected async createUser(): Promise<User> {
+        // Create new user row 
+        const runResult = await this.db.run('INSERT INTO users DEFAULT VALUES');
+        if (!runResult || runResult.lastID === undefined) {  
+            throw new Error("Serializable Creation Failed: Failed to create db entry for new user!");
+        } else {
+            let u = new User(runResult.lastID);
+            u.writeTo(new DatabaseWriter(this.db));
+            return u;
+        }
+    } */
+
+    /** 
+     * Creates a new CourseProject object and its corresponding database entity.
+     * Will overwrite the Databases Default Values with any defaults from 
+     * CourseProject class and its constructor!
+     */
+    /* protected async createCourseProject(): Promise<CourseProject> {
+        // Create new user row 
+        const runResult = await this.db.run('INSERT INTO projects DEFAULT VALUES');
+        if (!runResult || runResult.lastID === undefined) {  
+            throw new Error("Serializable Creation Failed: Failed to create db entry for new project!");
+        } else {
+            let u = new CourseProject(runResult.lastID);
+            u.writeTo(new DatabaseWriter(this.db));
+            return u;
+        }
+    } */
+
+
+
+}

--- a/server/src/Serializer/DatabaseWriter.ts
+++ b/server/src/Serializer/DatabaseWriter.ts
@@ -1,0 +1,105 @@
+import { Database } from "sqlite";
+import { Admin } from "../Models/Admin";
+import { Serializable } from "../Serializer/Serializable";
+import { User } from "../Models/User";
+import { Writer } from "./Writer";
+import { CourseProject } from "../Models/CourseProject";
+import { Course } from "../Models/Course";
+import { ProjectMember } from "../Models/ProjectMember";
+import { ProjectParticipation } from "../Models/ProjectParticipation";
+
+/**
+ * Reader Class
+ * 
+ * Reads/Writes Serializable Entities to SQLite Database
+ * 
+ */
+export class DatabaseWriter implements Writer {
+    /**
+     * Dictionary to be filled with attributes to be written in a single SQL call.
+     */
+    protected attributes: {[attributeName: string]: string | number | null} = {};
+    protected toHandle: Array<Serializable> = new Array();
+    protected wasHandled: Set<{tableName: string, id: number}> = new Set();
+    protected db: Database;
+
+    constructor(db: Database) {    
+        this.db = db;
+    }
+
+    async writeRoot(rootObject: Serializable) {
+        /** handle writing referenced objects recursively if required! */
+        this.toHandle = new Array();
+        this.wasHandled = new Set();
+        this.toHandle.push(rootObject);
+
+        let obj: Serializable | undefined; 
+        while ((obj = this.toHandle.pop()) !== undefined) {
+            // reset attributes dict
+            this.attributes = {};
+            // get table string based on class.
+            const table = this.getTableNameFromClass(obj);
+            /* Make object write its attribute values. They are gathered in attributes dictionary. */
+            obj.writeTo(this);
+            /* Compile SQL query from attributes */
+            const assignments = Object.keys(this.attributes)
+                .map(key => `${key} = :${key}`)
+                .join(", ");
+            /* compile parameters map from attributes */
+            const params = Object.fromEntries(
+                Object.entries(this.attributes).map(([key, value]) => [`:${key}`, value])
+            );
+            await this.db.run(
+                `UPDATE ${table} SET ${assignments} WHERE id = :id`,
+                params
+            );
+
+            if ('getId' in obj && typeof obj.getId === 'function') {
+                this.wasHandled.add({tableName: table, id: obj.getId()})
+            }   
+        }
+
+    }
+
+    
+    writeObject<T extends Serializable>(attributeName: string, objRef: T | null): void {
+        //console.log("Writing "+ attributeName);
+        // if object is not defined write NULL to db
+        if (objRef === null) {
+            this.attributes[attributeName] = "NULL";
+        } else if ('getId' in objRef && typeof objRef.getId === 'function') { 
+            // make sure Object has an ID and a getter.
+            this.attributes[attributeName] = objRef.getId();
+            if (!this.wasHandled.has({
+                tableName: this.getTableNameFromClass(objRef), 
+                id: objRef.getId()
+            })) {
+                this.toHandle.push(objRef);
+                // console.log("Object "+ attributeName+ " will be handled");
+            }
+        } else {
+            throw new Error("Serialization for Object of type " + typeof objRef + " failed!");
+        }
+    }
+
+    writeString(attributeName: string, string: string | null): void {
+        this.attributes[attributeName] = string;
+    }
+
+    writeNumber(attributeName: string, number: number | null): void {
+        this.attributes[attributeName] = number;
+    }
+    
+    getTableNameFromClass(s: Serializable): string {
+        if (s instanceof User || s instanceof Admin) {
+            return "users";
+        } else if (s instanceof Course) {
+            return "courses";
+        } else if (s instanceof CourseProject) {
+            return "projects";
+        /** @todo Add further tables/Classes! */
+        } else {
+            throw new Error("Unknown Serializable! Probably not implemented yet!");
+        }
+    }
+}

--- a/server/src/Serializer/Reader.ts
+++ b/server/src/Serializer/Reader.ts
@@ -1,0 +1,37 @@
+import { Serializable } from "../Serializer/Serializable";
+
+/**
+ * Generic Reader
+ */
+export interface Reader {
+    /**
+     * readRoot() contains the main loop which reads all objects.
+     * Any specification which objects to read can be passed to the constructor
+     * of the classes implementing this interface.
+     */
+    readRoot<T extends Serializable>(Constructor: new (...args: any[]) => T): T | Promise<T | T[]>;
+
+    /**
+     * Writes an object to backend. First writes the reference and then queues the Object for writing, if it was not handled previously.
+     * @param attributeName Name used to identify the object reference when reading/writing.
+     */
+    readObject(attributeName: string, className: string): Promise<Serializable | null> ;
+
+    /**
+     * Reads a string from backend with @param attributeName.
+     * @param attributeName Name used to identify the attribute when reading/writing.
+     */
+    readString(attributeName: string): string | null;
+
+    /**
+     * Reads a number from backend with @param attributeName.
+     * @param attributeName Name used to identify the attribute when reading/writing.
+     */
+    readNumber(attributeName: string): number | null;
+
+    /**
+     * 
+     * @todo Figure out, what ts type goes here!
+     */
+    // readDateTime(attributeName: String): ???; 
+}

--- a/server/src/Serializer/Serializable.ts
+++ b/server/src/Serializer/Serializable.ts
@@ -1,0 +1,22 @@
+import { initializeDB } from "../databaseInitializer";
+import { Reader } from "./Reader";
+import { Writer } from "../Serializer/Writer";
+import { User } from "../Models/User";
+
+
+/**
+ * For object creation please use a SerializableFactory!
+ */
+export interface Serializable {
+    /**
+     * Reads attributes with the specified Reader.
+     * @param reader Reader Object to read from. E.g. a DatabaseReader.
+     */
+    readFrom(reader: Reader): void;
+
+    /**
+     * Writes attributes with the specified Writer
+     * @param writer Writer Object to write attributes. E.g. a DatabaseWriter
+     */
+    writeTo(writer: Writer): void;
+}

--- a/server/src/Serializer/SerializableFactory.ts
+++ b/server/src/Serializer/SerializableFactory.ts
@@ -1,0 +1,12 @@
+import { Serializable } from "./Serializable";
+
+/**
+ * Factory for creating new Serializables backend-specifically.
+ */
+export interface SerializableFactory {
+    /**
+     * Creates a new object of given class. Also does any backend activity required for 
+     * proper object creation.
+     */
+    create(className: string): Promise<Serializable>;
+}

--- a/server/src/Serializer/Writer.ts
+++ b/server/src/Serializer/Writer.ts
@@ -1,0 +1,40 @@
+import { Serializable } from "./Serializable";
+
+/**
+ * Generic Writer
+ */
+export interface Writer {
+    /**
+     * writeRoot() contains the main loop which writes @param rootObject
+     * and all referenced objects.
+     * @param rootObject Object to be written.
+     */
+    writeRoot(rootObject: Serializable): void;
+
+    /**
+     * Writes an object to backend. First writes the reference and then queues the Object for writing, if it was not handled previously.
+     * @param attributeName Name used to identify the object reference when reading/writing.
+     * @param objRef Serializable to be written.
+     */
+    writeObject<T extends Serializable>(attributeName: string, objRef: T | null): void;
+
+    /**
+     * Writes @param string to backend with @param attributeName.
+     * @param attributeName Name used to identify the attribute when reading/writing.
+     * @param string Attribute Value.
+     */
+    writeString(attributeName: string, string: String | null): void;
+
+    /**
+     * Writes @param number to backend with @param attributeName.
+     * @param attributeName Name used to identify the attribute when reading/writing.
+     * @param number Attribute Value.
+     */
+    writeNumber(attributeName: string, number: number | null): void;
+
+    /**
+     * 
+     * @todo Figure out, what ts type goes here!
+     */
+    // writeDateTime(attributeName: String, dateTime: ???): void; 
+}

--- a/server/src/UserManager.ts
+++ b/server/src/UserManager.ts
@@ -1,0 +1,20 @@
+import { Database } from "sqlite";
+import { ObjectHandler } from "./ObjectHandler";
+import { DatabaseSerializableFactory } from "./Serializer/DatabaseSerializableFactory";
+import { User } from "./Models/User";
+
+export class UserManager {
+    protected db: Database;
+    protected oh: ObjectHandler;
+
+    constructor (db: Database) {
+        this.db = db;
+        this.oh = new ObjectHandler();
+    }
+
+    public async createUser (): Promise<User> {
+        const dbsf = new DatabaseSerializableFactory(this.db);
+        const proj = await dbsf.create("User") as User;
+        return proj;
+    }
+}

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -6,9 +6,14 @@ import { Database } from 'sqlite';
 import { UserStatus, UserStatusEnum } from './userStatus';
 import { Request, Response, NextFunction } from 'express';
 import { ObjectHandler } from './ObjectHandler';
+import { User } from "./Models/User";
 
 
 import { comparePassword, hashPassword } from './hash';
+import { DatabaseSerializableFactory } from './Serializer/DatabaseSerializableFactory';
+import { DatabaseWriter } from './Serializer/DatabaseWriter';
+import { DatabaseResultSetReader } from './Serializer/DatabaseResultSetReader';
+import { writer } from 'repl';
 
 dotenv.config();
 
@@ -31,12 +36,21 @@ export const register = async (req: Request, res: Response, db: Database) => {
   const hashedPassword = await hashPassword(password);
 
   try {
-    await db.run('INSERT INTO users (name, email, password) VALUES (?, ?, ?)', [name, email, hashedPassword]);
+    const writer = new DatabaseWriter(db);
+    const dbsf = new DatabaseSerializableFactory(db);
+    const oh = new ObjectHandler();
+    
+    // await db.run('INSERT INTO users (name, email, password) VALUES (?, ?, ?)', [name, email, hashedPassword]);
+    const u = await dbsf.create("User") as User;
+    u.setName(name);
+    u.setEmail(email);
+    u.setPassword(hashedPassword);
+    writer.writeRoot(u);
     res.status(201).json({ message: 'User registered successfully' });
 
     // Generate confirm email TOKEN
-    const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
-    if (!user) {
+    // const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
+    if (!oh.getUserByMail(email, db)) {
       console.error('Email not found after registration');
       return;
     }
@@ -46,10 +60,10 @@ export const register = async (req: Request, res: Response, db: Database) => {
 
     console.log(`Generated token: ${token}, Expiry time: ${expire}`);
 
-    await db.run(
-      'UPDATE users SET confirmEmailToken = ?, confirmEmailExpire = ? WHERE email = ?',
-      [token, expire, email]
-    );
+    u.setConfirmEmailToken(token);
+    u.setConfirmEmailExpire(expire);
+    writer.writeRoot(u);
+    // await db.run('UPDATE users SET confirmEmailToken = ?, confirmEmailExpire = ? WHERE email = ?', [token, expire, email]);
 
     await sendConfirmEmail(email, token);
 
@@ -68,17 +82,24 @@ export const login = async (req: Request, res: Response, db: Database) => {
   }
 
   try {
-    const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
+    const oh = new ObjectHandler();
+
+    // const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
+    const user = await oh.getUserByMail(email, db);
     if (!user) {
       return res.status(400).json({ message: 'Invalid email' });
     }
 
-    const isValidPassword = await comparePassword(password, user.password);
+    const userPassword = user.getPassword();
+    if (userPassword === null) {
+      return res.status(400).json({ message: 'No password set for user' });
+    }
+    const isValidPassword = await comparePassword(password, userPassword);
     if (!isValidPassword) {
       return res.status(400).json({ message: 'Invalid password' });
     }
 
-    let st: string = user.status;
+    let st: string = user.getStatus();
     let userStatus: UserStatus = new UserStatus(st as UserStatusEnum);
     if (userStatus.getStatus() == UserStatusEnum.unconfirmed) {
       return res.status(400).json({ message: 'Email not confirmed. Please contact system admin.' });
@@ -88,11 +109,8 @@ export const login = async (req: Request, res: Response, db: Database) => {
       return res.status(400).json({ message: 'User account is removed. Please contact system admin.' });
     }
 
-    
-
-
-    const token = jwt.sign({ id: user.id }, 'your_jwt_secret', { expiresIn: '1h' });
-    res.status(200).json({ token, name: user.name, email: user.email, githubUsername: user.githubUsername });
+    const token = jwt.sign({ id: user.getId() }, 'your_jwt_secret', { expiresIn: '1h' });
+    res.status(200).json({ token, name: user.getName(), email: user.getEmail(), githubUsername: user.getGithubUsername() });
   } catch (error) {
     console.error('Error during login:', error);
     res.status(500).json({ message: 'Login failed' });
@@ -108,7 +126,7 @@ export const checkOwnership = (db: Database, oh: ObjectHandler) => {
 
         try {
             const decoded = jwt.verify(token, secret) as { id: string; email: string };
-            const userFromTokenId = await oh.getUser(decoded.id, db);
+            const userFromTokenId = await oh.getUser(Number(decoded.id), db);
             const userFromParamsId = await oh.getUserByMail(req.body.email, db);
 
             if(!userFromTokenId || !userFromParamsId) {
@@ -162,7 +180,9 @@ export const forgotPassword = async (req: Request, res: Response, db: Database) 
   const { email } = req.body;
 
   try {
-    const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
+    const oh = new ObjectHandler();
+    const writer = new DatabaseWriter(db);
+    const user = await oh.getUserByMail(email, db);
     if (!user) {
       return res.status(404).json({ message: 'Email not found' });
     }
@@ -172,10 +192,10 @@ export const forgotPassword = async (req: Request, res: Response, db: Database) 
 
     console.log(`Generated token: ${token}, Expiry time: ${expire}`);
 
-    await db.run(
-      'UPDATE users SET resetPasswordToken = ?, resetPasswordExpire = ? WHERE email = ?',
-      [token, expire, email]
-    );
+    // await db.run('UPDATE users SET resetPasswordToken = ?, resetPasswordExpire = ? WHERE email = ?', [token, expire, email]);
+    user.setResetPasswordToken(token);
+    user.setResetPasswordExpire(expire);
+    writer.writeRoot(user);
 
     await sendPasswordResetEmail(email, token);
 
@@ -195,17 +215,25 @@ export const resetPassword = async (req: Request, res: Response, db: Database) =
   }
 
   try {
+    const writer = new DatabaseWriter(db);
+
     const currentTime = Date.now();
     const user = await db.get('SELECT * FROM users WHERE resetPasswordToken = ?', [token]);
+    const reader = new DatabaseResultSetReader(user, db);
+    const u = await reader.readRoot(user) as User;
     
     console.log('User retrieved from database:', user);
 
-    if (!user || user.resetPasswordExpire < currentTime) {
+    if (!u || u.getResetPasswordExpire() !== null || u.getResetPasswordExpire() as number < currentTime) {
       return res.status(400).json({ message: 'Invalid or expired token' });
     }
 
     const hashedPassword = await hashPassword(newPassword);
-    await db.run('UPDATE users SET password = ?, resetPasswordToken = NULL, resetPasswordExpire = NULL WHERE id = ?', [hashedPassword, user.id]);
+    // await db.run('UPDATE users SET password = ?, resetPasswordToken = NULL, resetPasswordExpire = NULL WHERE id = ?', [hashedPassword, user.id]);
+    u.setPassword(hashedPassword);
+    u.setResetPasswordExpire(null);
+    u.setResetPasswordToken(null);
+    writer.writeRoot(u);
 
     res.status(200).json({ message: 'Password has been reset' });
   } catch (error) {
@@ -256,8 +284,11 @@ export const confirmEmail = async (req: Request, res: Response, db: Database) =>
   console.log('Token:', token);
 
   try {
+    const writer = new DatabaseWriter(db);
     const currentTime = Date.now();
     const user = await db.get('SELECT * FROM users WHERE confirmEmailToken = ?', [token]);
+    const reader = new DatabaseResultSetReader(user, db);
+    const u = await reader.readRoot(user) as User;
     
     console.log('User retrieved from database:', user);
 
@@ -266,6 +297,10 @@ export const confirmEmail = async (req: Request, res: Response, db: Database) =>
     }
 
     await db.run('UPDATE users SET status = "confirmed", confirmEmailToken = NULL, confirmEmailExpire = NULL WHERE email = ?', [user.email]);
+    u.setStatus("confirmed");
+    u.setConfirmEmailToken(null);
+    u.setConfirmEmailExpire(null);
+    writer.writeRoot(u);
 
     res.status(200).json({ message: 'Email has been confirmed' });
   } catch (error) {
@@ -277,17 +312,26 @@ export const confirmEmail = async (req: Request, res: Response, db: Database) =>
 export const sendConfirmationEmail = async (req: Request, res: Response, db: Database) => {
   const { email } = req.body;
   try {
-    const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
-    let st: string = user.status;
+    const oh = new ObjectHandler();
+    const writer = new DatabaseWriter(db);
+    // const user = await db.get('SELECT * FROM users WHERE email = ?', [email]);
+    const user = await oh.getUserByMail(email, db);
+    if (!user) {
+      return res.status(400).json({ message: 'User not found' });
+    }
+    let st: string = user.getStatus();
     let userStatus: UserStatus = new UserStatus(st as UserStatusEnum);
-    if (!user || userStatus.getStatus() != UserStatusEnum.unconfirmed) {
-      return res.status(400).json({ message: 'User not found or not unconfirmed' });
+    if (userStatus.getStatus() != UserStatusEnum.unconfirmed) {
+      return res.status(400).json({ message: 'User email not unconfirmed' });
     }
 
     const token = crypto.randomBytes(20).toString('hex');
     const expire = Date.now() + 3600000;
 
-    await db.run('UPDATE users SET confirmEmailToken = ?, confirmEmailExpire = ? WHERE email = ?', [token, expire, email]);
+    // await db.run('UPDATE users SET confirmEmailToken = ?, confirmEmailExpire = ? WHERE email = ?', [token, expire, email]);
+    user.setConfirmEmailToken(token);
+    user.setConfirmEmailExpire(expire);
+    writer.writeRoot(user);
     await sendConfirmEmail(email, token);
 
     res.status(200).json({ message: 'Confirmation email sent' });

--- a/server/src/databaseInitializer.ts
+++ b/server/src/databaseInitializer.ts
@@ -1,6 +1,10 @@
 import sqlite3 from 'sqlite3';
 import { open } from 'sqlite';
 import { hashPassword } from './hash';
+import { ObjectHandler } from './ObjectHandler';
+import { DatabaseSerializableFactory } from './Serializer/DatabaseSerializableFactory';
+import { User } from './Models/User';
+import { DatabaseWriter } from './Serializer/DatabaseWriter';
 
 const DEFAULT_USER = {
   name: "admin",
@@ -13,6 +17,8 @@ export async function initializeDB() {
     filename: './myDatabase.db',
     driver: sqlite3.Database,
   });
+
+  const oh = new ObjectHandler();
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS users (
@@ -30,61 +36,72 @@ export async function initializeDB() {
     )
   `);
 
-  const userCount = await db.get('SELECT COUNT(*) AS count FROM users');
-  if (userCount.count === 0) {
+  const userCount = await oh.getUserCount(db);
+  if (!userCount || userCount === 0) {
     const { name, email, password } = DEFAULT_USER;
-    await db.run(
-      `INSERT INTO users (name, email, password, status, userRole) VALUES (?, ?, ?, ?, ?)`,
-      [name, email, await hashPassword(password), 'confirmed', "ADMIN"]
-    );
+    // await db.run(`INSERT INTO users (name, email, password, status) VALUES (?, ?, ?, ?)`, [name, email, await hashPassword(password), 'confirmed']);
+    const dbsf = new DatabaseSerializableFactory(db);
+    const writer = new DatabaseWriter(db);
+    const admin = await dbsf.create("User") as User;
+    admin.setName(name);
+    admin.setEmail(email);
+    admin.setPassword(await hashPassword(password));
+    admin.setStatus('confirmed');
+    writer.writeRoot(admin);
     console.log(`Default admin user created: (email: '${email}', password: '${password}')`);
   }
 
   await db.exec(`
-    CREATE TABLE IF NOT EXISTS project (
+    CREATE TABLE IF NOT EXISTS projects (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      projectName TEXT,
-      projectGroupName TEXT
+      projectName TEXT UNIQUE,
+      courseId INTEGER,
+      FOREIGN KEY (courseId) REFERENCES courses(id)
     )
   `);
 
   await db.exec(`
-    CREATE TABLE IF NOT EXISTS projectGroup (
+    CREATE TABLE IF NOT EXISTS courses (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       semester TEXT,
-      projectGroupName TEXT UNIQUE
+      courseName TEXT UNIQUE
     )
   `);
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS user_projects (
-      userEmail TEXT,
-      projectName TEXT,
+      userId INTEGER,
+      projectId INTEGER,
+      role TEXT,
       url TEXT,
-      PRIMARY KEY (userEmail, projectName),
-      FOREIGN KEY (userEmail) REFERENCES users(email)
+      PRIMARY KEY (userId, projectId),
+      FOREIGN KEY (userId) REFERENCES users(id),
+      FOREIGN KEY (projectId) REFERENCES projects(id)
     )
     `);
 
   await db.exec(`
-CREATE TABLE IF NOT EXISTS sprints (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  projectGroupName TEXT NOT NULL,
-  sprintName TEXT NOT NULL,
-  endDate DATETIME NOT NULL
-)
+    CREATE TABLE IF NOT EXISTS sprints (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      courseId INTEGER NOT NULL,
+      sprintName TEXT NOT NULL,
+      endDate DATETIME NOT NULL,
+      FOREIGN KEY (courseId) REFERENCES courses(id)
+    )
   `);
 
   await db.exec(`
     CREATE TABLE IF NOT EXISTS happiness (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      projectGroupName TEXT,
-      projectName TEXT,
-      userEmail TEXT,
+      projectId INTEGER,
+      userId INTEGER,
       happiness INTEGER,
-      sprintName TEXT,
-      timestamp DATETIME DEFAULT CURRENT_TIMESTAMP)
-      `);
+      sprintId INTEGER,
+      timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (userId) REFERENCES users(id),
+      FOREIGN KEY (projectId) REFERENCES projects(id)
+    )
+  `);
 
   return db;
 }

--- a/server/src/projectManagement.ts
+++ b/server/src/projectManagement.ts
@@ -2,113 +2,91 @@ import { Database } from "sqlite";
 import { Request, Response } from "express";;
 import nodemailer from 'nodemailer';
 import dotenv from 'dotenv';
+import { DatabaseManager } from "./Models/DatabaseManager";
 
 import { Semester } from "./Models/Semester";
 
 dotenv.config();
 
-export const createProjectGroup = async (req: Request, res: Response, db: Database) => {
-    const { semester, projectGroupName } = req.body;
-    if (!semester || !projectGroupName) {
-        return res.status(400).json({ message: "Please fill in semester and project group name" });
-    }
+export const createCourse = async (req: Request, res: Response, db: Database) => {
+  const { semester, courseName } = req.body;
+  if (!semester || !courseName) {
+    return res.status(400).json({ message: "Please fill in semester and course name" });
+  }
 
-    let semesterInput = semester; // Raw input from the request
-    try {
-        const semester = Semester.create(semesterInput); // Uses the Semester's internal validation
-        await db.run("INSERT INTO projectGroup (semester, projectGroupName) VALUES (?, ?)", [semester.toString(), projectGroupName]);
-        await db.exec(`
-            CREATE TABLE IF NOT EXISTS "${projectGroupName}" (
-              id INTEGER PRIMARY KEY AUTOINCREMENT,
-              projectName TEXT UNIQUE
-            )
-        `);
-        res.status(201).json({ message: "Project group created successfully" });
-    } catch (error) {
-        console.error("Error during project group creation:", error);
-        res.status(500).json({ message: "Project group creation failed", error });
-    }
+  let semesterInput = semester; // Raw input from the request
+  try {
+    const semester = Semester.create(semesterInput); // Uses the Semester's internal validation
+    await db.run("INSERT INTO courses (semester, courseName) VALUES (?, ?)", [semester.toString(), courseName]);
+    res.status(201).json({ message: "Course created successfully" });
+  } catch (error) {
+    console.error("Error during project group creation:", error);
+    res.status(500).json({ message: "Course creation failed", error });
+  }
 }
 
 export const createProject = async (req: Request, res: Response, db: Database) => {
-    const { projectGroupName, projectName } = req.body;
+  const { courseName, projectName } = req.body;
 
-    if (!projectGroupName || !projectName) {
-        return res.status(400).json({ message: "Please fill in project group name and project name" });
+  if (!courseName || !projectName) {
+    return res.status(400).json({ message: "Please fill in project group name and project name" });
+  }
+
+  try {
+    const courseId = DatabaseManager.getCourseIdFromName(db, courseName);
+    const user = await db.get('SELECT * FROM courses WHERE id = ?', [courseId]);
+    if (!user) {
+      return res.status(400).json({ message: 'Course Not Found' });
     }
 
-    try {
-        const user = await db.get('SELECT * FROM projectGroup WHERE projectGroupName = ?', [projectGroupName]);
-        if (!user) {
-            return res.status(400).json({ message: 'Project Group Not Found' });
-        }
+    await db.run(`INSERT INTO project (projectName, courseId) VALUES (?, ?)`, [projectName, courseId]);
 
-        await db.run(`INSERT INTO ${projectGroupName} (projectName) VALUES (?)`, [projectName]);
-        await db.run(`INSERT INTO project (projectName, projectGroupName) VALUES (?, ?)`, [projectName, projectGroupName]);
-        await db.exec(`
-            CREATE TABLE IF NOT EXISTS "${projectName}" (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                memberName TEXT,
-                memberRole TEXT,
-                memberEmail TEXT UNIQUE
-            )
-        `);
-        res.status(201).json({ message: "Project created successfully" });
-    } catch (error) {
-        console.error("Error during project creation:", error);
-        res.status(500).json({ message: "Project creation failed", error });
-    }
+    res.status(201).json({ message: "Project created successfully" });
+  } catch (error) {
+    console.error("Error during project creation:", error);
+    res.status(500).json({ message: "Project creation failed", error });
+  }
 };
 
 
-export const editProjectGroup = async (req: Request, res: Response, db: Database) => {
-    const { projectGroupName, newSemester, newProjectGroupName } = req.body;
+export const editCourse = async (req: Request, res: Response, db: Database) => {
+  const { courseName, newSemester, newCourseName } = req.body;
 
-    if (!newSemester || !newProjectGroupName) {
-        return res.status(400).json({ message: "Please fill in semester and project group name" });
-    }
+  if (!newSemester || !newCourseName) {
+    return res.status(400).json({ message: "Please fill in semester and project group name" });
+  } 
 
-    try {
-        const semester = Semester.create(newSemester); // @todo Shared ValueType method?
-        console.log(`Executing SQL: UPDATE projectGroup SET semester = '${semester.toString()}', projectGroupName = '${newProjectGroupName}' WHERE projectGroupName = '${projectGroupName}'`);
+  try {
+    const semester = Semester.create(newSemester); // @todo Shared ValueType method?
+    const courseId = DatabaseManager.getCourseIdFromName(db, courseName);
+    console.log(`Executing SQL: UPDATE courses SET semester = '${semester.toString()}', courseName = '${newCourseName}' WHERE id = '${courseId}'`);
 
-        await db.run(
+    await db.run(
+      `UPDATE courses SET semester = ?, courseName = ? WHERE id = ?`,
+      [semester.toString(), newCourseName, courseId]
+    );
 
-            `UPDATE projectGroup SET semester = ?, projectGroupName = ? WHERE projectGroupName = ?`,
-            [semester.toString(), newProjectGroupName, projectGroupName]
-        );
-
-        res.status(201).json({ message: "Project group edited successfully" });
-    } catch (error) {
-        console.error("Error during project group edition:", error);
-        res.status(500).json({ message: "Project group edited failed", error });
-    }
+    res.status(201).json({ message: "Course edited successfully" });
+  } catch (error) {
+    console.error("Error during Course edition:", error);
+    res.status(500).json({ message: "Course edited failed", error });
+  }
 }
 
 export const editProject = async (req: Request, res: Response, db: Database) => {
-    const { newProjectGroupName, projectName, newProjectName } = req.body;
+  const { newCourseName, projectName, newProjectName } = req.body;
 
-    if (!newProjectGroupName || !newProjectName) {
-        return res.status(400).json({ message: "Please fill in project group name and project name" });
-    }
+  if (!newCourseName || !newProjectName) {
+    return res.status(400).json({ message: "Please fill in project group name and project name" });
+  }
 
-    try {
-        // Check if table names need to be quoted
-        const quotedProjectName = `"${projectName}"`;
-        const quotedNewProjectName = `"${newProjectName}"`;
-
-        //get the old project group name
-        const oldProjectGroupName = await db.get('SELECT projectGroupName FROM project WHERE projectName = ?', [projectName]);
-        await db.run(`ALTER TABLE ${quotedProjectName} RENAME TO ${quotedNewProjectName}`);
-
-        await db.run(
-            `UPDATE project SET projectName = ?, projectGroupName = ? WHERE projectName = ?`,
-            [newProjectName, newProjectGroupName, projectName]
-        );
-
-        // update the table $projectGroupName to $newProjectGroupName
-        await db.run(`UPDATE ${oldProjectGroupName.projectGroupName} SET projectName = ? WHERE projectName = ?`, [newProjectName, projectName]);
-
+  try {
+    const newCourseId = DatabaseManager.getCourseIdFromName(db, newCourseName);
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName);
+    await db.run(
+      `UPDATE projects SET projectName = ?, courseId = ? WHERE id = ?`,
+      [newProjectName, newCourseId, projectId]
+    );
         res.status(201).json({ message: "Project edited successfully" });
     } catch (error) {
         console.error("Error during project edition:", error);
@@ -116,383 +94,355 @@ export const editProject = async (req: Request, res: Response, db: Database) => 
     }
 };
 
+    res.status(201).json({ message: "Project edited successfully" });
+  } catch (error) {
+    console.error("Error during project edition:", error);
+    res.status(500).json({ message: "Project edition failed", error });
+  }
+};
+
 
 
 export const getSemesters = async (req: Request, res: Response, db: Database) => {
-    try {
-        const semesters = await db.all("SELECT DISTINCT semester FROM projectGroup");
-        res.json(semesters);
-    } catch (error) {
-        console.error("Error during semester retrieval:", error);
-        res.status(500).json({ message: "Failed to retrieve semesters", error });
-    }
+  try {
+    const semesters = await db.all("SELECT DISTINCT semester FROM courses");
+    res.json(semesters);
+  } catch (error) {
+    console.error("Error during semester retrieval:", error);
+    res.status(500).json({ message: "Failed to retrieve semesters", error });
+  }
 }
 
-export const getProjectGroups = async (req: Request, res: Response, db: Database) => {
-    const { semester } = req.query;
-    let query = "SELECT * FROM projectGroup";
-    let params = [];
+export const getCourses = async (req: Request, res: Response, db: Database) => {
+  const { semester } = req.query;
+  let query = "SELECT * FROM courses";
+  let params = [];
 
-    if (semester) {
-        query += " WHERE semester = ?";
-        params.push(semester);
-    }
+  if (semester) {
+    query += " WHERE semester = ?";
+    params.push(semester);
+  }
 
-    try {
-        const projectGroups = await db.all(query, params);
-        res.json(projectGroups);
-    } catch (error) {
-        console.error("Error during project group retrieval:", error);
-        res.status(500).json({ message: "Failed to retrieve project groups", error });
-    }
+  try {
+    const projectGroups = await db.all(query, params);
+    res.json(projectGroups);
+  } catch (error) {
+    console.error("Error during course retrieval:", error);
+    res.status(500).json({ message: "Failed to retrieve courses", error });
+  }
 };
 
 export const getProjects = async (req: Request, res: Response, db: Database) => {
-    const { projectGroupName } = req.query;
+  const { courseName } = req.query;
 
-    if (!projectGroupName) {
-        return res.status(400).json({ message: "Project group name is required" });
-    }
+  if (!courseName) {
+    return res.status(400).json({ message: "Course id is required" });
+  }
 
-    try {
-        const projects = await db.all(`SELECT * FROM "${projectGroupName}"`);
-        res.json(projects);
-    } catch (error) {
-        console.error("Error during project retrieval:", error);
-        res.status(500).json({ message: `Failed to retrieve projects for project group ${projectGroupName}`, error });
-    }
+  try {
+    const courseId = DatabaseManager.getCourseIdFromName(db, courseName.toString());
+    const projects = await db.all("SELECT * FROM projects WHERE courseId = ?", [courseId]);
+    res.json(projects);
+  } catch (error) {
+    console.error("Error during project retrieval:", error);
+    res.status(500).json({ message: `Failed to retrieve projects for course ${courseName}`, error });
+  }
 };
 
 export const joinProject = async (req: Request, res: Response, db: Database) => {
-    const { projectName, memberName, memberRole, memberEmail } = req.body;
+  const { projectName, userEmail, role } = req.body;
 
-    if (!memberRole) {
-        return res.status(400).json({ message: "Please fill in your role" });
+  if (!role) {
+    return res.status(400).json({ message: "Please fill in your role" });
+  }
+
+  try {
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail);
+    const isMember = await db.get(`SELECT * FROM user_projects WHERE userId = ? AND projectId = ?`, [userId, projectId]);
+    if (isMember) {
+      return res.status(400).json({ message: "You have already joined this project" });
     }
 
-    try {
-        const user = await db.get(`SELECT * FROM "${projectName}" WHERE memberName = ?`, [memberName]);
-        if (user) {
-            return res.status(400).json({ message: "You have already joined this project" });
-        }
-        const email = await db.get(`SELECT * FROM "${projectName}" WHERE memberEmail = ?`, [memberEmail]);
-        if (email) {
-            return res.status(400).json({ message: "You have already joined this project" });
-        }
+    await db.run('INSERT INTO user_projects (userId, projectId, memberRole ) VALUES (?, ?, ?)', [userId, projectId, role]);
+    res.status(201).json({ message: "Joined project successfully" });
 
-        await db.run(`INSERT INTO "${projectName}" (memberName, memberRole, memberEmail) VALUES (?, ?, ?)`, [memberName, memberRole, memberEmail]);
-        await db.run('INSERT INTO user_projects (userEmail, projectName) VALUES (?, ?)', [memberEmail, projectName]);
-        res.status(201).json({ message: "Joined project successfully" });
-
-    } catch (error) {
-        console.error("Error during joining project:", error);
-        res.status(500).json({ message: "Failed to join project", error });
-    }
+  } catch (error) {
+    console.error("Error during joining project:", error);
+    res.status(500).json({ message: "Failed to join project", error });
+  }
 };
 
 export const leaveProject = async (req: Request, res: Response, db: Database) => {
-    const { projectName, memberEmail } = req.body;
+  const { userEmail, projectName } = req.body;
 
-    try {
-        const isMember = await db.get(`SELECT * FROM "${projectName}" WHERE memberEmail = ?`, [memberEmail]);
-        if (!isMember) {
-            return res.status(400).json({ message: "You are not a member of this project" });
-        }
-
-        await db.run(`DELETE FROM "${projectName}" WHERE memberEmail = ?`, [memberEmail]);
-        await db.run('DELETE FROM user_projects WHERE userEmail = ? AND projectName = ?', [memberEmail, projectName]);
-
-        res.status(200).json({ message: "Left project successfully" });
-    } catch (error) {
-        console.error("Error during leaving project:", error);
-        res.status(500).json({ message: "Failed to leave project", error });
+  try {
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail);
+    const isMember = await db.get(`SELECT * FROM user_projects WHERE userId = ? AND projectId = ?`, [userId, projectId]);
+    if (!isMember) {
+      return res.status(400).json({ message: "You are not a member of this project" });
     }
+    await db.run('DELETE FROM user_projects WHERE userId = ? AND projectId = ?', [userId, projectId]);
+
+    res.status(200).json({ message: "Left project successfully" });
+  } catch (error) {
+    console.error("Error during leaving project:", error);
+    res.status(500).json({ message: "Failed to leave project", error });
+  }
 }
 
 export const getUserProjects = async (req: Request, res: Response, db: Database) => {
-    const { userEmail } = req.query;
+  const { userEmail } = req.query;
 
-    try {
-        const projects = await db.all('SELECT projectName FROM user_projects WHERE userEmail = ?', [userEmail]);
-        res.json(projects);
-    } catch (error) {
-        console.error("Error during retrieving user projects:", error);
-        res.status(500).json({ message: "Failed to retrieve user projects", error });
-    }
+  if (!userEmail) {
+    return res.status(400).json({ message: "User Email is required" });
+  }
+
+  try {
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail.toString());
+    const projects = await db.all('SELECT projectId FROM user_projects WHERE userId = ?', [userId]);
+    res.json(projects);
+  } catch (error) {
+    console.error("Error during retrieving user projects:", error);
+    res.status(500).json({ message: "Failed to retrieve user projects", error });
+  }
 };
 
-export const getUserProjectGroups = async (req: Request, res: Response, db: Database) => {
-    const { projectName } = req.query;
+export const getUserCourses = async (req: Request, res: Response, db: Database) => {
+  const { projectName } = req.query;
 
-    try {
-        const projectGroups = await db.get('SELECT projectGroupName FROM project WHERE projectName = ?', [projectName]);
-        if (projectGroups) {
-            res.json(projectGroups);
-        } else {
-            res.status(404).json({ message: "Project group not found" });
-        }
-    } catch (error) {
-        console.error("Error during retrieving user project groups:", error);
-        res.status(500).json({ message: "Failed to retrieve user project groups", error });
+  if (!projectName) {
+    return res.status(400).json({ message: "Project Name is required" });
+  }
+
+
+  try {
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName?.toString());
+    const projectGroups = await db.get('SELECT DISTINCT courseId FROM projects WHERE id = ?', [projectId]);
+    if (projectGroups) {
+      res.json(projectGroups);
+    } else {
+      res.status(404).json({ message: "Course not found" });
     }
+  } catch (error) {
+    console.error("Error during retrieving user courses:", error);
+    res.status(500).json({ message: "Failed to retrieve user courses", error });
+  }
 };
 
 export const getUsers = async (req: Request, res: Response, db: Database) => {
-    try {
-        const user = await db.all('SELECT * FROM users');
-        if (user) {
-            res.json(user);
-        } else {
-            res.status(404).json({ message: "User not found" });
-        }
-    } catch (error) {
-        console.error("Error during retrieving user status:", error);
-        res.status(500).json({ message: "Failed to retrieve user status", error });
+  try {
+    const user = await db.all('SELECT * FROM users');
+    if (user) {
+      res.json(user);
+    } else {
+      res.status(404).json({ message: "User not found" });
     }
+  } catch (error) {
+    console.error("Error during retrieving user status:", error);
+    res.status(500).json({ message: "Failed to retrieve user status", error });
+  }
 }
 
 export const getUsersByStatus = async (req: Request, res: Response, db: Database) => {
-    const { status } = req.query;
+  const { status } = req.query;
 
-    try {
-        const user = await db.all('SELECT * FROM users WHERE status = ?', [status]);
-        if (user) {
-            res.json(user);
-        } else {
-            res.status(404).json({ message: "User not found" });
-        }
-    } catch (error) {
-        console.error("Error during retrieving user status:", error);
-        res.status(500).json({ message: "Failed to retrieve user status", error });
+  try {
+    const user = await db.all('SELECT * FROM users WHERE status = ?', [status]);
+    if (user) {
+      res.json(user);
+    } else {
+      res.status(404).json({ message: "User not found" });
     }
-}
-
-export const getUserRole = async (req: Request, res: Response, db: Database) => {
-    const { userEmail } = req.query;
-
-    try {
-        const user = await db.get('SELECT userRole FROM users WHERE email = ?', [userEmail]);
-        if (user) {
-            res.json(user);
-        } else {
-            res.status(404).json({ message: "User not found" });
-        }
-    } catch (error) {
-        console.error("Error during retrieving user role:", error);
-        res.status(500).json({ message: "Failed to retrieve user role", error });
-    }
-}
-
-export const updateUserRole = async (req: Request, res: Response, db: Database) => {
-    const { email, role } = req.body;
-
-    if (!email || !role) {
-        return res.status(400).json({ message: "Please provide email and role" });
-    }
-
-    try {
-        await db.run('UPDATE users SET userRole = ? WHERE email = ?', [role, email]);
-        res.status(200).json({ message: "User role updated successfully" });
-    } catch (error) {
-        console.error("Error during updating user role:", error);
-        res.status(500).json({ message: "Failed to update user role", error });
-    }
+  } catch (error) {
+    console.error("Error during retrieving user status:", error);
+    res.status(500).json({ message: "Failed to retrieve user status", error });
+  }
 }
 
 export const updateUserStatus = async (req: Request, res: Response, db: Database) => {
-    const { email, status } = req.body;
+  const { userEmail, status } = req.body;
 
-    if (!email || !status) {
-        return res.status(400).json({ message: "Please provide email and status" });
-    }
+  if (!userEmail || !status) {
+    return res.status(400).json({ message: "Please provide email and status" });
+  }
 
-    if (status == "suspended") {
-        sendSuspendedEmail(email);
-    } else if (status == "removed") {
-        sendRemovedEmail(email);
-    }
+  if (status == "suspended") {
+    sendSuspendedEmail(userEmail);
+  } else if (status == "removed") {
+    sendRemovedEmail(userEmail);
+  }
 
-    try {
-        await db.run('UPDATE users SET status = ? WHERE email = ?', [status, email]);
-        res.status(200).json({ message: "User status updated successfully" });
-    } catch (error) {
-        console.error("Error during updating user status:", error);
-        res.status(500).json({ message: "Failed to update user status", error });
-    }
+  try {
+    await db.run('UPDATE users SET status = ? WHERE email = ?', [status, userEmail]);
+    res.status(200).json({ message: "User status updated successfully" });
+  } catch (error) {
+    console.error("Error during updating user status:", error);
+    res.status(500).json({ message: "Failed to update user status", error });
+  }
 }
 
 export const updateAllConfirmedUsers = async (req: Request, res: Response, db: Database) => {
-    const { status } = req.body;
+  const { status } = req.body;
 
-    if (!status) {
-        return res.status(400).json({ message: 'Status is required' });
+  if (!status) {
+    return res.status(400).json({ message: 'Status is required' });
+  }
+
+  try {
+    const result = await db.run(
+      'UPDATE users SET status = ? WHERE status = "confirmed"',
+      [status]
+    );
+
+    if (result.changes === 0) {
+      return res.status(404).json({ message: 'No confirmed users found to update' });
     }
 
-
-
-    try {
-
-        const confirmedUsers = await db.all('SELECT * FROM users WHERE status = "confirmed"');
-
-
-        const result = await db.run(
-            'UPDATE users SET status = ? WHERE status = "confirmed"',
-            [status]
-        );
-
-
-
-        if (result.changes === 0) {
-            return res.status(404).json({ message: 'No confirmed users found to update' });
-        }
-
-        res.status(200).json({ message: `All confirmed users have been updated to ${status}` });
-    } catch (error) {
-        console.error('Error updating confirmed users:', error);
-        res.status(500).json({ message: 'Failed to update confirmed users' });
-    }
+    res.status(200).json({ message: `All confirmed users have been updated to ${status}` });
+  } catch (error) {
+    console.error('Error updating confirmed users:', error);
+    res.status(500).json({ message: 'Failed to update confirmed users' });
+  }
 };
 
 export const sendSuspendedEmail = async (email: string) => {
-    const transporter = nodemailer.createTransport({
-        host: 'smtp-auth.fau.de',
-        port: 465,
-        secure: true,
-        auth: {
-            user: process.env.EMAIL_USER_FAU,
-            pass: process.env.EMAIL_PASS_FAU,
-        },
-    });
+  const transporter = nodemailer.createTransport({
+    host: 'smtp-auth.fau.de',
+    port: 465,
+    secure: true,
+    auth: {
+      user: process.env.EMAIL_USER_FAU,
+      pass: process.env.EMAIL_PASS_FAU,
+    },
+  });
 
-    const mailOptions = {
-        from: '"Mini-Meco" <shu-man.cheng@fau.de>',
-        to: email,
-        subject: 'Account Suspended',
-        text: `Your account has been suspended. Please contact the administrator for more information.`,
-    };
+  const mailOptions = {
+    from: '"Mini-Meco" <shu-man.cheng@fau.de>',
+    to: email,
+    subject: 'Account Suspended',
+    text: `Your account has been suspended. Please contact the administrator for more information.`,
+  };
 
-    try {
-        // @todo: Uncomment the following lines to send email
-        // const info = await transporter.sendMail(mailOptions);
-        // console.log('Account suspended email sent: %s', info.messageId);
-    } catch (error) {
-        console.error('error sending suspended email:', error);
-        throw new Error('There was an error sending the email');
-    }
+  try {
+    // @todo: Uncomment the following lines to send email
+    // const info = await transporter.sendMail(mailOptions);
+    // console.log('Account suspended email sent: %s', info.messageId);
+  } catch (error) {
+    console.error('error sending suspended email:', error);
+    throw new Error('There was an error sending the email');
+  }
 }
 
 export const sendRemovedEmail = async (email: string) => {
-    const transporter = nodemailer.createTransport({
-        host: 'smtp-auth.fau.de',
-        port: 465,
-        secure: true,
-        auth: {
-            user: process.env.EMAIL_USER_FAU,
-            pass: process.env.EMAIL_PASS_FAU,
-        },
-    });
+  const transporter = nodemailer.createTransport({
+    host: 'smtp-auth.fau.de',
+    port: 465,
+    secure: true,
+    auth: {
+      user: process.env.EMAIL_USER_FAU,
+      pass: process.env.EMAIL_PASS_FAU,
+    },
+  });
 
-    const mailOptions = {
-        from: '"Mini-Meco" <shu-man.cheng@fau.de>',
-        to: email,
-        subject: 'Account Removed',
-        text: `Your account has been removed. Please contact the administrator for more information.`,
-    };
+  const mailOptions = {
+    from: '"Mini-Meco" <shu-man.cheng@fau.de>',
+    to: email,
+    subject: 'Account Removed',
+    text: `Your account has been removed. Please contact the administrator for more information.`,
+  };
 
-    try {
-        // @todo: Uncomment the following lines to send email
-        // const info = await transporter.sendMail(mailOptions);
-        // console.log('Account removed email sent: %s', info.messageId);
-    } catch (error) {
-        console.error('error sending removed email:', error);
-        throw new Error('There was an error sending the email');
-    }
+  try {
+    // @todo: Uncomment the following lines to send email
+    // const info = await transporter.sendMail(mailOptions);
+    // console.log('Account removed email sent: %s', info.messageId);
+  } catch (error) {
+    console.error('error sending removed email:', error);
+    throw new Error('There was an error sending the email');
+  }
 }
 
 
 export const getEnrolledCourses = async (req: Request, res: Response, db: Database) => {
+  const { userEmail } = req.query;
+  if (!userEmail) {
+    return res.status(400).json({ message: "User email is required" });
+  }
 
-    const { userEmail } = req.query;
-
-    if (!userEmail) {
-        return res.status(400).json({ message: "User email is required" });
-    }
-
-    try {
-        const courses = await db.all(
-            `SELECT DISTINCT projectGroupName 
+  try {
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail.toString());
+    const courses = await db.all(
+      `SELECT DISTINCT projects.courseId 
          FROM user_projects 
-         JOIN project USING (projectName)
-         WHERE userEmail = ?`,
-            [userEmail]
-        );
-        res.json(courses);
-    } catch (error) {
-        console.error("Error during retrieving courses of user:", error);
-        res.status(500).json({ message: "Failed to retrieve courses of user", error });
-    }
+         INNER JOIN projects ON user_projects.projectId = projects.id
+         WHERE user_projects.userId = ?`,
+      [userId]
+    );
+    res.json(courses);
+  } catch (error) {
+    console.error("Error during retrieving courses of user:", error);
+    res.status(500).json({ message: "Failed to retrieve courses of user", error });
+  }
 };
 
 export const getProjectsForCourse = async (req: Request, res: Response, db: Database) => {
-    const { courseName, userEmail } = req.query;
+  const { courseName, userEmail } = req.query;
 
-    if (!courseName || !userEmail) {
-        return res.status(400).json({ message: "Course name and user email are required" });
-    }
+  if (!courseName || !userEmail) {
+    return res.status(400).json({ message: "Course Name and user Email are required" });
+  }
 
-    try {
-        const enrolledProjects = await db.all(
-            `SELECT projectName
-             FROM project
-             JOIN user_projects USING (projectName)
-             WHERE projectGroupName = ? AND userEmail = ?`,
-            [courseName, userEmail]
-        );
+  try {
+    const courseId = DatabaseManager.getCourseIdFromName(db, courseName.toString());
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail.toString());
 
-        const availableProjects = await db.all(
-            `SELECT p.projectName
-             FROM project p
-             LEFT JOIN user_projects up ON (p.projectName = up.projectName) AND (up.userEmail = ?)
-             WHERE p.projectGroupName = ? AND up.userEmail IS NULL`,
-            [userEmail, courseName]
-        );
+    const enrolledProjects = await db.all(
+      `SELECT projects.id
+             FROM user_projects
+             INNER JOIN projects ON user_projects.prjectId = projects.id
+             WHERE courseId = ? AND userId = ?`,
+      [courseId, userId]
+    );
 
-        res.json({ enrolledProjects, availableProjects });
-    } catch (error) {
-        console.error("Error retrieving projects for course:", error);
-        res.status(500).json({ message: "Failed to retrieve projects for course", error });
-    }
+    const availableProjects = await db.all(
+      `SELECT p.id
+             FROM projects p
+             LEFT JOIN user_projects up ON (p.id = up.projectId) AND (up.userId = ?)
+             WHERE p.courseId = ? AND up.userid IS NULL`,
+      [userId, courseId]
+    );
+
+    res.json({ enrolledProjects, availableProjects });
+  } catch (error) {
+    console.error("Error retrieving projects for course:", error);
+    res.status(500).json({ message: "Failed to retrieve projects for course", error });
+  }
 };
 
 export const getRoleForProject = async (req: Request, res: Response, db: Database) => {
-    const { projectName, userEmail } = req.query;
+  const { projectName, userEmail } = req.query;
 
-    if (!projectName || !userEmail) {
-        return res.status(400).json({ message: "Project name and user email are required" });
+  if (!projectName || !userEmail) {
+    return res.status(400).json({ message: "Project name and user email are required" });
+  }
+
+  try {
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName.toString());
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail.toString());
+    const role = await db.get(
+      `SELECT memberRole
+             FROM user_projects
+             WHERE userId = ? AND projectId = ?`,
+      [userId, projectId]
+    );
+
+    if (!role) {
+      return res.status(404).json({ message: "Role not found" });
     }
-
-    const validTableName = typeof projectName === 'string' && /^[a-zA-Z0-9_]+$/.test(projectName);
-    if (!validTableName) {
-        return res.status(400).json({ message: "Invalid project name" });
-    }
-
-    try {
-
-        const role = await db.get(
-            `SELECT memberRole
-             FROM ${projectName}
-             WHERE memberEmail = ?`,
-            [userEmail]
-        );
-
-        if (!role) {
-            return res.status(404).json({ message: "Role not found" });
-        }
-        res.json({ role: role.memberRole });
-    } catch (error) {
-        console.error("Error retrieving project role", error);
-        res.status(500).json({ message: "Failed to retrieve project role", error });
-    }
+    res.json({ role: role.memberRole });
+  } catch (error) {
+    console.error("Error retrieving project role", error);
+    res.status(500).json({ message: "Failed to retrieve project role", error });
+  }
 }
-
-

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -4,27 +4,25 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import { initializeDB } from './databaseInitializer';
 import { ObjectHandler } from './ObjectHandler';
-import { 
-    register, login, forgotPassword, resetPassword, confirmEmail, sendConfirmationEmail 
+import {
+  register, login, forgotPassword, resetPassword, confirmEmail, sendConfirmationEmail
 } from './auth';
-import { 
-    createProjectGroup, createProject, editProjectGroup, editProject, getProjectGroups, getProjects, 
-    getSemesters, joinProject, leaveProject, getUserProjects, getUserProjectGroups, getUsersByStatus, 
-    updateUserStatus, updateAllConfirmedUsers, 
-    getEnrolledCourses,
-    getProjectsForCourse,
-    getRoleForProject,
-    getUsers,
-    getUserRole,
-    updateUserRole
+import {
+  createCourse, createProject, editCourse, editProject, getCourses, getProjects,
+  getSemesters, joinProject, leaveProject, getUserProjects, getUserCourses, getUsersByStatus,
+  updateUserStatus, updateAllConfirmedUsers,
+  getEnrolledCourses,
+  getProjectsForCourse,
+  getRoleForProject,
+  getUsers
 } from './projectManagement';
-import { 
-    sendStandupsEmail, saveHappinessMetric, createSprints, getProjectHappinessMetrics, getSprints, 
-    getProjectCurrentSprint
+import {
+  sendStandupsEmail, saveHappinessMetric, createSprints, getProjectHappinessMetrics, getSprints,
+  getProjectCurrentSprint
 } from './projectFeatures';
-import { 
-    changeEmail, changePassword, setUserGitHubUsername, getUserGitHubUsername, setUserProjectURL, 
-    getUserProjectURL 
+import {
+  changeEmail, changePassword, setUserGitHubUsername, getUserGitHubUsername, setUserProjectURL,
+  getUserProjectURL
 } from './userConfig';
 import { checkOwnership } from './auth';
 
@@ -45,11 +43,11 @@ initializeDB().then((db) => {
   });
 
   // course endpoints
-  app.get('/course', (req, res) => { getProjectGroups(req, res, db) });
-  app.post('/course', (req, res) => { createProjectGroup(req, res, db); });
-  app.put('/course', (req, res) => { editProjectGroup(req, res, db); });
+  app.get('/course', (req, res) => { getCourses(req, res, db) });
+  app.post('/course', (req, res) => { createCourse(req, res, db); });
+  app.put('/course', (req, res) => { editCourse(req, res, db); });
   app.get('/course/courseProjects', (req, res) => getProjectsForCourse(req, res, db));
-  app.get('/course/user', (req, res) => { getUserProjectGroups(req, res, db) });
+  app.get('/course/user', (req, res) => { getUserCourses(req, res, db) });
 
   // courseProject endpoints
   app.get('/courseProject', (req, res) => { getProjects(req, res, db) });
@@ -87,16 +85,15 @@ initializeDB().then((db) => {
   app.get('/user/role', (req, res) => { getUserRole(req, res, db) });
   app.post('/user/role', (req, res) => { updateUserRole(req, res, db) });
 
-
   app.post('/projConfig/changeURL', (req, res) => setUserProjectURL(req, res, db));
   app.get('/semesters', (req, res) => { getSemesters(req, res, db) });
   app.post('/projConfig/leaveProject', (req, res) => leaveProject(req, res, db));
   app.post('/session', (req, res) => login(req, res, db));
 
 
-    app.listen(port, () => {
-        console.log(`Server running on http://localhost:${port}`);
-    });
+  app.listen(port, () => {
+    console.log(`Server running on http://localhost:${port}`);
+  });
 }).catch(error => {
-    console.error('Failed to initialize the database:', error);
+  console.error('Failed to initialize the database:', error);
 });

--- a/server/src/tests/dummy.test.ts
+++ b/server/src/tests/dummy.test.ts
@@ -1,8 +1,0 @@
-import { describe, it, expect } from "vitest";
-
-describe('Dummy test', () => {
-  it('should always return true', () => {
-    let dummystatement = true
-    expect(dummystatement).toBe(true);
-  });
-});

--- a/server/src/tests/serializer.test.ts
+++ b/server/src/tests/serializer.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { initializeDB } from "../databaseInitializer";
+import { Database } from "sqlite";
+import { ObjectHandler } from "../ObjectHandler";
+import { User } from "../Models/User";
+import { DatabaseSerializableFactory } from "../Serializer/DatabaseSerializableFactory";
+import { Course } from "../Models/Course";
+import { DatabaseWriter } from "../Serializer/DatabaseWriter";
+import { DatabaseResultSetReader } from "../Serializer/DatabaseResultSetReader";
+import { CourseProject } from "../Models/CourseProject";
+import { CourseManager } from "../CourseManager";
+import { getProjectsForCourse } from "../projectManagement";
+
+/** You need to delete the DB each time before running tests, unfortunately! */
+
+describe('Basic serializer read/write test', async () => {
+  const db: Database = await initializeDB();
+  const oh = new ObjectHandler();
+  const dbsf = new DatabaseSerializableFactory(db);
+  it('Default Admin User created properly', async () => {
+    const nameObj = await db.get(`SELECT name FROM users WHERE email = ?`, "sys@admin.org");
+    expect(!nameObj).toBe(false);
+    const name: string = nameObj.name;
+    expect(name).toBe("admin");
+  });
+
+  it('Reading default Admin User', async () => {
+    const u: User | null = await oh.getUser(1, db);
+    expect(u !== null).toBe(true);
+    expect(u?.getName()).toBe("admin");
+  });
+
+  it('Create new Course and Project', async () => {
+    const c: Course = await dbsf.create("Course") as Course;
+    c.setName("ADAP");
+    c.setSemester("WS2425");
+    (new DatabaseWriter(db)).writeRoot(c);
+    const result = db.all(`SELECT * FROM courses`);
+    const courses = await (new DatabaseResultSetReader(result, db)).readRoot<Course>(Course) as Course[];
+    // expect(courses.length).toBe(1);
+    expect(courses[0].getName()).toBe("ADAP");
+    const c2 = await oh.getCourse(c.getId(), db) as Course;
+    expect(c2 !== null).toBe(true);
+    expect(c2.getName()).toBe(c.getName());
+    const c3 = await oh.getSerializableFromId(c.getId(), "Course", db) as Course;
+    expect(c3.getName()).toBe(c.getName());
+
+    const p: CourseProject = await dbsf.create("CourseProject") as CourseProject;
+    p.setCourse(c);
+    p.setName("proj");
+    (new DatabaseWriter(db)).writeRoot(p);
+    const res = db.get(`SELECT * FROM projects WHERE projectName = "proj"`);
+    let p3 = await (new DatabaseResultSetReader(res, db).readRoot<CourseProject>(CourseProject)) as CourseProject;
+    console.log(JSON.stringify(p3));
+    expect(p3.getName()).toBe(p.getName());
+    expect(p3.getCourse() === null).toBe(false);
+    expect(p3.getCourse()?.getName()).toBe(p.getCourse()?.getName());
+    const p2 = await oh.getCourseProject(p.getId(), db) as CourseProject;
+    expect(p2.getName()).toBe(p.getName());
+    expect(p2.getCourse()?.getName()).toBe(c.getName());
+
+    const cm: CourseManager = new CourseManager(db);
+    const ps = await cm.getProjectsForCourse(c);
+    expect(ps.length).toBe(1);
+    expect(ps[0].getId()).toBe(1);
+
+  });
+
+});

--- a/server/src/userConfig.ts
+++ b/server/src/userConfig.ts
@@ -1,56 +1,51 @@
 import { Database } from "sqlite";
 import { Request, Response } from "express";
 import { hashPassword } from "./hash";
+import { DatabaseManager } from "./Models/DatabaseManager";
 
 export const changeEmail = async (req: Request, res: Response, db: Database) => {
-    const { newEmail, oldEmail } = req.body;
-    if (!newEmail) {
-        return res.status(400).json({ message: 'Please fill in new email!' });
-      }
-      else if (!newEmail.includes('@')) {
-        return res.status(400).json({ message: 'Invalid email address' });
-      }
+  const { newEmail, oldEmail } = req.body;
+  if (!newEmail) {
+    return res.status(400).json({ message: 'Please fill in new email!' });
+  }
+  else if (!newEmail.includes('@')) {
+    return res.status(400).json({ message: 'Invalid email address' });
+  }
 
-    try {
-        const projects = await db.all(`SELECT projectName FROM user_projects WHERE userEmail = ?`, [oldEmail])
-
-        await db.run(`UPDATE users SET email = ? WHERE email = ?`, [newEmail, oldEmail]);
-        await db.run(`UPDATE user_projects SET userEmail = ? WHERE userEmail = ?`, [newEmail, oldEmail]);
-        await db.run(`UPDATE happiness SET userEmail = ? WHERE userEmail = ?`, [newEmail, oldEmail]);
-
-        for (let i = 0; i < projects.length; i++) {
-            await db.run(`UPDATE "${projects[i].projectName}" SET memberEmail = ? WHERE memberEmail = ?`, [newEmail, oldEmail]);
-        }
-        res.status(200).json({ message: "Email updated successfully" });
-    } catch (error) {
-        console.error("Error updating email:", error);
-        res.status(500).json({ message: "Failed to update email", error });
-    }
+  try {
+    const userId = DatabaseManager.getUserIdFromEmail(db, oldEmail);
+    await db.run(`UPDATE users SET email = ? WHERE id = ?`, [newEmail, userId]);
+    res.status(200).json({ message: "Email updated successfully" });
+  } catch (error) {
+    console.error("Error updating email:", error);
+    res.status(500).json({ message: "Failed to update email", error });
+  }
 }
 
 export const changePassword = async (req: Request, res: Response, db: Database) => {
-    const { email, password } = req.body;
+  const { userEmail, password } = req.body;
 
-    if (!password) {
-        return res.status(400).json({ message: 'Please fill in new password!' });
-      }
-      else if (password.length < 8) {
-        return res.status(400).json({ message: 'Password must be at least 8 characters long' });
-      }
+  if (!password) {
+    return res.status(400).json({ message: 'Please fill in new password!' });
+  }
+  else if (password.length < 8) {
+    return res.status(400).json({ message: 'Password must be at least 8 characters long' });
+  }
 
-    const hashedPassword = await hashPassword(password);
+  const hashedPassword = await hashPassword(password);
 
-    try {
-        await db.run(`UPDATE users SET password = ? WHERE email = ?`, [hashedPassword, email]);
-        res.status(200).json({ message: "Password updated successfully" });
-    } catch (error) {
-        console.error("Error updating password:", error);
-        res.status(500).json({ message: "Failed to update password", error });
-    }
+  try {
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail);
+    await db.run(`UPDATE users SET password = ? WHERE id = ?`, [hashedPassword, userId]);
+    res.status(200).json({ message: "Password updated successfully" });
+  } catch (error) {
+    console.error("Error updating password:", error);
+    res.status(500).json({ message: "Failed to update password", error });
+  }
 }
 
 export const setUserProjectURL = async (req: Request, res: Response, db: Database) => {
-  const {email, URL, project} = req.body;
+  const { userEmail, URL, projectName } = req.body;
 
   if (!URL) {
     return res.status(400).json({ message: 'Please fill in URL!' });
@@ -60,7 +55,10 @@ export const setUserProjectURL = async (req: Request, res: Response, db: Databas
   }
 
   try {
-    await db.run(`UPDATE user_projects SET url = ? WHERE userEmail = ? AND projectName = ?`, [URL, email, project]);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail);
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName);
+
+    await db.run(`UPDATE user_projects SET url = ? WHERE userId = ? AND projectId = ?`, [URL, userId, projectId]);
     res.status(200).json({ message: "URL added successfully" });
   } catch (error) {
     console.error("Error adding URL:", error);
@@ -69,10 +67,16 @@ export const setUserProjectURL = async (req: Request, res: Response, db: Databas
 }
 
 export const getUserProjectURL = async (req: Request, res: Response, db: Database) => {
-  const {email, project} = req.query;
+  const { userEmail, projectName } = req.query;
+
+  if(!userEmail || !projectName) {
+    return res.status(400).json({ message: 'User Email and Project Name are mandatory!' });
+  }
 
   try {
-    const urlObj = await db.get(`SELECT url FROM user_projects WHERE userEmail = ? AND projectName = ?`, [email, project]);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail.toString());
+    const projectId = DatabaseManager.getProjectIdFromName(db, projectName.toString());
+    const urlObj = await db.get(`SELECT url FROM user_projects WHERE userId = ? AND projectId = ?`, [userId, projectId]);
     const url = urlObj ? urlObj.url : null;
     res.status(200).json({ url });
   } catch (error) {
@@ -82,12 +86,13 @@ export const getUserProjectURL = async (req: Request, res: Response, db: Databas
 }
 
 export const setUserGitHubUsername = async (req: Request, res: Response, db: Database) => {
-  const {email, newGithubUsername} = req.body;
+  const { userEmail, newGithubUsername } = req.body;
   if (!newGithubUsername) {
     return res.status(400).json({ message: 'Please fill in GitHub username!' });
   }
   try {
-    await db.run(`UPDATE users SET githubUsername = ? WHERE email = ?`, [newGithubUsername, email]);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail);
+    await db.run(`UPDATE users SET githubUsername = ? WHERE id = ?`, [newGithubUsername, userId]);
     res.status(200).json({ message: "GitHub username added successfully" });
   } catch (error) {
     console.error("Error adding GitHub username:", error);
@@ -96,9 +101,15 @@ export const setUserGitHubUsername = async (req: Request, res: Response, db: Dat
 }
 
 export const getUserGitHubUsername = async (req: Request, res: Response, db: Database) => {
-  const {email} = req.query;
+  const { userEmail } = req.query;
+
+  if(!userEmail) {
+    return res.status(400).json({ message: 'User Email is mandatory!' });
+  }
+
   try {
-    const githubUsernameObj = await db.get(`SELECT githubUsername FROM users WHERE email = ?`, [email]);
+    const userId = DatabaseManager.getUserIdFromEmail(db, userEmail?.toString());
+    const githubUsernameObj = await db.get(`SELECT githubUsername FROM users WHERE id = ?`, [userId]);
     const githubUsername = githubUsernameObj ? githubUsernameObj.githubUsername : null;
     res.status(200).json({ githubUsername });
   } catch (error) {


### PR DESCRIPTION
This issue closes #55.

## Summary

As far as I understand it, the `vitest run` command implicitly searches for test files and executes them all if they are in the `src/tests/...` directory. Due to the design of the mono-repository, it is sufficient to specify the `--prefix client/server` in our `package.json` root. Or that is exactly the reason why vitest run is sufficient. Anyway, if we want it more explicit, then we should rather think about configuring the workspace(s) as an option, e.g. if we want specific tests for each environment.

If there are no files, the test will fail, so I've decided to leave the `client/.../dummy.test.ts` there and will be sure to provide a test file for my widget later :)

## How can this be tested?

Go to the root directory `cd mini-meco` and execute `npm run test` in the console. 

## Screenshots

No UI changes were made

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] New and existing unit tests pass locally with my changes: No useState failed
- [ ] I have lowered the linter errors. Before: 23. After: 23

