### PR TITLE
GitHubRepoURL value type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "sqlite": "^5.1.1"
       },
       "devDependencies": {
+        "@octokit/types": "^13.8.0",
         "@typescript-eslint/eslint-plugin": "^8.18.2",
         "@typescript-eslint/parser": "^8.18.2",
         "concurrently": "^9.1.0",
@@ -1422,9 +1423,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -1512,12 +1513,12 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.2.tgz",
-      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^22.2.0"
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -12681,9 +12682,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
-      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+      "version": "23.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
+      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "11.3.6",
@@ -12738,11 +12739,11 @@
       }
     },
     "@octokit/types": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.2.tgz",
-      "integrity": "sha512-WpbZfZUcZU77DrSW4wbsSgTPfKcp286q3ItaIgvSbBpZJlu6mnYXAkjZz6LVZPXkEvLIM8McanyZejKTYUHipA==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
+      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
       "requires": {
-        "@octokit/openapi-types": "^22.2.0"
+        "@octokit/openapi-types": "^23.0.1"
       }
     },
     "@pkgjs/parseargs": {
@@ -18651,9 +18652,9 @@
           "dev": true
         },
         "rollup": {
-          "version": "4.30.1",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-          "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+          "version": "4.30.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.0.tgz",
+          "integrity": "sha512-sDnr1pcjTgUT69qBksNF1N1anwfbyYG6TBQ22b03bII8EdiUQ7J0TlozVaTMjT/eEJAO49e1ndV7t+UZfL1+vA==",
           "dev": true,
           "requires": {
             "@rollup/rollup-android-arm-eabi": "4.30.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "npm run lint --prefix client && npm run lint --prefix server"
   },
   "devDependencies": {
+    "@octokit/types": "^13.8.0",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
     "concurrently": "^9.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "nodemon --watch src --ext .ts,.js --exec \"npm run build && node dist/server.js\"",
     "build": "tsc",
-    "test":"vitest run tests/semester.test.ts --reporter=verbose",
+    "test":"vitest run tests/ --reporter=verbose",
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {

--- a/server/src/Models/CourseProject.ts
+++ b/server/src/Models/CourseProject.ts
@@ -1,10 +1,11 @@
 import { Email } from "../email";
+import { GitHubRepoURL } from "./GitHubRepoURL";
 
 export class CourseProject {
 
     public userEmail: Email = new Email("");
     public projectName: string = "";
-    public url: string = "";
+    public gitHubRepoURL: GitHubRepoURL = new GitHubRepoURL("");
 
     constructor() {
         // dummy course project for set impl

--- a/server/src/Models/GitHubRepoURL.ts
+++ b/server/src/Models/GitHubRepoURL.ts
@@ -1,4 +1,4 @@
-import { URL } from "url";
+import { URL } from "node:url";
 import { IllegalArgumentException } from "../Exceptions/IllegalArgumentException";
 
 

--- a/server/src/Models/GitHubRepoURL.ts
+++ b/server/src/Models/GitHubRepoURL.ts
@@ -1,0 +1,63 @@
+import { URL } from "url";
+import { IllegalArgumentException } from "../Exceptions/IllegalArgumentException";
+
+
+export class GitHubRepoURL {
+    private readonly url: URL;
+
+    /**
+     * Value type for GitHub URLs. Only http:// and https:// URLs are supported.
+     *
+     * @param input - The URL to be parsed as a string
+     * @returns The value type object
+     */
+    constructor(input: string) {
+        const url = URL.parse(input);
+        if (!url)
+            throw new IllegalArgumentException("Invalid URL");
+        this.url = url;
+
+        if (!this.isGithubUrl())
+            throw new IllegalArgumentException("Not a GitHub URL");
+
+        if (!this.isValidProtocol())
+            throw new IllegalArgumentException("Unsupported protocol");
+        
+        if (!this.isRepo())
+            throw new IllegalArgumentException("The URL has no repository structure");
+        }
+    
+    /**
+     * @returns The whole URL as a string
+    */
+   public asString() {
+       return this.url.href;
+    }
+
+    /**
+     * Checks if the URL hostname is github.com
+     * @returns True if the check succeeds, else false
+     */
+    private isGithubUrl() {
+        return this.url.hostname === "github.com" ||
+            this.url.hostname === "www.github.com";
+    }
+
+    /**
+     * Checks if the URL protocol is http or https
+     * @returns True if the check succeeds, else false
+     */
+    private isValidProtocol() {
+        return this.url.protocol === "http:" ||
+            this.url.protocol === "https:";
+    }
+
+    /**
+     * Checks if the URL pathname contains exactly two slashes with something
+     * behind them
+     * @returns True if the check succeeds, else false
+     */
+    private isRepo() {
+        return (this.url.pathname.match(/\/./g) || []).length === 2;
+    }
+}

--- a/server/src/tests/gitHubRepoURL.test.ts
+++ b/server/src/tests/gitHubRepoURL.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { GitHubRepoURL } from "../Models/GitHubRepoURL";
+
+describe("GitHubRepoURL", () => {
+  it("should create a new value", () => {
+    expect(new GitHubRepoURL("https://github.com/riehlegroup/mini-meco"));
+  });
+
+  it("asString() should return the whole URL", () => {
+    const url = new GitHubRepoURL("https://github.com:73/riehlegroup/mini-meco.git");
+    expect(url.asString()).toBe("https://github.com:73/riehlegroup/mini-meco.git");
+  });
+
+  it("should throw if URL isn't a GitHub URL", () => {
+    expect(() => new GitHubRepoURL("https://gitlab.com/riehlegroup/mini-meco")).toThrow();
+  });
+
+  it("should throw if URL isn't of supported structure", () => {
+    expect(() => new GitHubRepoURL("git@github.com:riehlegroup/mini-meco.git")).toThrow();
+  });
+
+  it("should throw if URL has unsupported protocoll", () => {
+    expect(() => new GitHubRepoURL("ssh://github.com/riehlegroup/mini-meco")).toThrow();
+  });
+
+  it("should throw if URL has no repo structure", () => {
+    expect(() => new GitHubRepoURL("https://github.com/riehlegroup")).toThrow();
+  });
+});

--- a/server/src/userStatus.ts
+++ b/server/src/userStatus.ts
@@ -11,8 +11,8 @@ export class UserStatus {
     // Define valid transitions between states
     private static validTransitions: Record<UserStatusEnum, UserStatusEnum[]> = {
         [UserStatusEnum.confirmed]: [UserStatusEnum.suspended],
-        [UserStatusEnum.unconfirmed]: [UserStatusEnum.confirmed, UserStatusEnum.suspended],
-        [UserStatusEnum.suspended]: [UserStatusEnum.confirmed],
+        [UserStatusEnum.unconfirmed]: [UserStatusEnum.confirmed, UserStatusEnum.suspended, UserStatusEnum.removed],
+        [UserStatusEnum.suspended]: [UserStatusEnum.confirmed, UserStatusEnum.removed],
         [UserStatusEnum.removed]: [],
     };
 


### PR DESCRIPTION
This issue closes #28 .

The value type accepts a URL with the following constraints as input:
- protocol: `http` or `https`
- hostname: `www.github.com` or `github.com`
- pathname: structure of a repo, i. e. `/abc/def`

SSH git URLs are unsupported as of now. If those should be considered in
the future, the class structure probably has to be modified.

## How can this be tested?
`npm run test`

## Screenshots
No UI changes made.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have lowered the linter errors. Before: 18. After: 16

