### PR TITLE
Create React widget for Password value type

### DIFF
--- a/client/src/components/Components/PasswordWidget.tsx
+++ b/client/src/components/Components/PasswordWidget.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Password, PasswordStrength } from "server/src/Models/Password.ts";
+
+// Helper function to convert password strength to a descriptive label and color
+const getStrengthInfo = (strength: PasswordStrength) => {
+  switch (strength) {
+    case PasswordStrength.VeryWeak:
+      return { label: "Very Weak", color: "#ff4d4f" };
+    case PasswordStrength.Weak:
+      return { label: "Weak", color: "#ff7a45" };
+    case PasswordStrength.Medium:
+      return { label: "Medium", color: "#faad14" };
+    case PasswordStrength.Strong:
+      return { label: "Strong", color: "#73d13d" };
+    case PasswordStrength.VeryStrong:
+      return { label: "Very Strong", color: "#52c41a" };
+    default:
+      return { label: "", color: "transparent" };
+  }
+};
+
+interface PasswordWidgetProps {
+  password: Password;
+  onPasswordChange: (password: string) => void;
+  action: string;
+}
+
+const PasswordWidget: React.FC<PasswordWidgetProps> = ({
+  password,
+  onPasswordChange,
+  action,
+}) => {
+  const strength: PasswordStrength = password.getStrength();
+  const { label, color } = getStrengthInfo(strength);
+
+  return (
+    <>
+      <input
+        className={"inputBox"}
+        type="password"
+        placeholder="Please enter your password"
+        value={password.getValue()}
+        onChange={(e) => onPasswordChange(e.target.value)}
+      />
+      {
+        // If the user is registering, show a password strength
+        action === "Registration" && password.getValue() != "" && (
+          <div style={{ whiteSpace: "nowrap" }}>
+            <span style={{ color: "black" }}>Password Strength: </span>
+            <br></br>
+            <strong style={{ color }}>{label}</strong>
+          </div>
+        )
+      }
+    </>
+  );
+};
+
+export default PasswordWidget;

--- a/client/src/components/Components/PasswordWidget.tsx
+++ b/client/src/components/Components/PasswordWidget.tsx
@@ -1,18 +1,43 @@
 import React from "react";
-import { Password, PasswordStrength } from "server/src/Models/Password.ts";
 
-// Helper function to convert password strength to a descriptive label and color
-const getStrengthInfo = (strength: PasswordStrength) => {
+const containsLowerAndUpperCase = (value: string): boolean =>
+  /(?=.*[a-z])(?=.*[A-Z])/.test(value);
+const containsNumber = (value: string): boolean => /\d/.test(value);
+const containsSpecialCharacter = (value: string): boolean =>
+  /[!@#$%^&*(),.?":{}|<>]/.test(value);
+
+const calculatePasswordStrength = (value: string): number => {
+  if (value.length < 8) {
+    return 1;
+  }
+
+  let strength = 1;
+  if (containsLowerAndUpperCase(value)) {
+    strength++;
+  }
+  if (containsNumber(value)) {
+    strength++;
+  }
+  if (containsSpecialCharacter(value)) {
+    strength++;
+  }
+  if (value.length >= 12) {
+    strength++;
+  }
+  return strength;
+};
+
+const getStrengthInfo = (strength: number) => {
   switch (strength) {
-    case PasswordStrength.VeryWeak:
+    case 1:
       return { label: "Very Weak", color: "#ff4d4f" };
-    case PasswordStrength.Weak:
+    case 2:
       return { label: "Weak", color: "#ff7a45" };
-    case PasswordStrength.Medium:
+    case 3:
       return { label: "Medium", color: "#faad14" };
-    case PasswordStrength.Strong:
+    case 4:
       return { label: "Strong", color: "#73d13d" };
-    case PasswordStrength.VeryStrong:
+    case 5:
       return { label: "Very Strong", color: "#52c41a" };
     default:
       return { label: "", color: "transparent" };
@@ -20,7 +45,7 @@ const getStrengthInfo = (strength: PasswordStrength) => {
 };
 
 interface PasswordWidgetProps {
-  password: Password;
+  password: string;
   onPasswordChange: (password: string) => void;
   action: string;
 }
@@ -30,28 +55,25 @@ const PasswordWidget: React.FC<PasswordWidgetProps> = ({
   onPasswordChange,
   action,
 }) => {
-  const strength: PasswordStrength = password.getStrength();
+  const strength = calculatePasswordStrength(password);
   const { label, color } = getStrengthInfo(strength);
 
   return (
     <>
       <input
-        className={"inputBox"}
+        className="inputBox"
         type="password"
         placeholder="Please enter your password"
-        value={password.getValue()}
+        value={password}
         onChange={(e) => onPasswordChange(e.target.value)}
       />
-      {
-        // If the user is registering, show a password strength
-        action === "Registration" && password.getValue() != "" && (
-          <div style={{ whiteSpace: "nowrap" }}>
-            <span style={{ color: "black" }}>Password Strength: </span>
-            <br></br>
-            <strong style={{ color }}>{label}</strong>
-          </div>
-        )
-      }
+      {action === "Registration" && password !== "" && (
+        <div style={{ whiteSpace: "nowrap" }}>
+          <span style={{ color: "black" }}>Password Strength: </span>
+          <br />
+          <strong style={{ color }}>{label}</strong>
+        </div>
+      )}
     </>
   );
 };

--- a/client/src/screens/Auth/LoginScreen.tsx
+++ b/client/src/screens/Auth/LoginScreen.tsx
@@ -4,27 +4,41 @@ import UserNameIcon from "./../../assets/UserNameIcon.png";
 import EmailIcon from "./../../assets/EmailIcon.png";
 import PasswordIcon from "./../../assets/PasswordIcon.png";
 import { useNavigate } from "react-router-dom";
+import { Password } from "server/src/Models/Password.ts";
+import PasswordWidget from "@/components/Components/PasswordWidget";
 
 const LoginScreen = () => {
   const navigate = useNavigate();
   const [action, setAction] = useState("Login");
   const [validationOn, setValidationOn] = useState(false);
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [password, setPassword] = useState(Password.create(""));
   const [name, setName] = useState("");
   const [message, setMessage] = useState("");
 
+  const handlePasswordChange = (value: string) => {
+    setPassword(Password.create(value));
+  };
+
   const handleSubmit = async () => {
+    console.log(password.getValue());
     if (!validationOn) {
       setValidationOn(true);
     }
 
-    if (!email || !password || (action === "Registration" && !name)) {
+    if (
+      !email ||
+      !password.getValue() ||
+      (action === "Registration" && !name)
+    ) {
       return;
     }
 
     const endpoint = action === "Registration" ? "/user" : "/session";
-    const body: { [key: string]: string } = { email, password };
+    const body: { [key: string]: string } = {
+      email,
+      password: password.getValue(),
+    };
     // Add name to the body if the action is Registration (not Login)
     if (action === "Registration") {
       body.name = name;
@@ -34,9 +48,9 @@ const LoginScreen = () => {
       const response = await fetch(`http://localhost:3000${endpoint}`, {
         method: "POST",
         headers: {
-          "Content-Type": "application/json", 
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify(body), 
+        body: JSON.stringify(body),
       });
 
       const data = await response.json();
@@ -74,10 +88,12 @@ const LoginScreen = () => {
         </div>
         <div className="inputs">
           {action === "Registration" && (
-            <div className={"input" + (validationOn && !name ? " validation" : "")}>
+            <div
+              className={"input" + (validationOn && !name ? " validation" : "")}
+            >
               <img className="username-icon" src={UserNameIcon} alt="" />
               <input
-                className={"inputBox"} 
+                className={"inputBox"}
                 type="text"
                 placeholder="Please enter your name"
                 value={name}
@@ -86,7 +102,9 @@ const LoginScreen = () => {
             </div>
           )}
 
-          <div className={"input" + (validationOn && !email ? " validation" : "")}>
+          <div
+            className={"input" + (validationOn && !email ? " validation" : "")}
+          >
             <img className="email-icon" src={EmailIcon} alt="" />
             <input
               className={"inputBox"}
@@ -96,15 +114,18 @@ const LoginScreen = () => {
               onChange={(e) => setEmail(e.target.value)}
             />
           </div>
-          <div className={"input" + (validationOn && !password ? " validation" : "")}>
+          <div
+            className={
+              "input" +
+              (validationOn && !password.getValue() ? " validation" : "")
+            }
+          >
             <img className="password-icon" src={PasswordIcon} alt="" />
-            <input
-              className={"inputBox"} 
-              type="password"
-              placeholder="Please enter your password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-            />
+            <PasswordWidget
+              password={password}
+              onPasswordChange={handlePasswordChange}
+              action={action}
+            ></PasswordWidget>
           </div>
         </div>
         {action === "Login" && (
@@ -114,7 +135,9 @@ const LoginScreen = () => {
         )}
         <div className="submit-container">
           <div
-            className={"submit " + (action === "Login" ? "primary" : "secondary")}
+            className={
+              "submit " + (action === "Login" ? "primary" : "secondary")
+            }
             onClick={() => {
               if (action === "Login") {
                 handleSubmit();
@@ -127,7 +150,9 @@ const LoginScreen = () => {
             Login
           </div>
           <div
-            className={"submit " + (action === "Registration" ? "primary" : "secondary")}
+            className={
+              "submit " + (action === "Registration" ? "primary" : "secondary")
+            }
             onClick={() => {
               if (action === "Registration") {
                 handleSubmit();
@@ -135,8 +160,8 @@ const LoginScreen = () => {
               } else {
                 setAction("Registration");
                 setValidationOn(false);
+              }
             }}
-          }
           >
             Sign Up
           </div>

--- a/client/src/screens/Auth/LoginScreen.tsx
+++ b/client/src/screens/Auth/LoginScreen.tsx
@@ -4,7 +4,6 @@ import UserNameIcon from "./../../assets/UserNameIcon.png";
 import EmailIcon from "./../../assets/EmailIcon.png";
 import PasswordIcon from "./../../assets/PasswordIcon.png";
 import { useNavigate } from "react-router-dom";
-import { Password } from "server/src/Models/Password.ts";
 import PasswordWidget from "@/components/Components/PasswordWidget";
 
 const LoginScreen = () => {
@@ -12,32 +11,27 @@ const LoginScreen = () => {
   const [action, setAction] = useState("Login");
   const [validationOn, setValidationOn] = useState(false);
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState(Password.create(""));
+  const [password, setPassword] = useState("");
   const [name, setName] = useState("");
   const [message, setMessage] = useState("");
 
   const handlePasswordChange = (value: string) => {
-    setPassword(Password.create(value));
+    setPassword(value);
   };
 
   const handleSubmit = async () => {
-    console.log(password.getValue());
     if (!validationOn) {
       setValidationOn(true);
     }
 
-    if (
-      !email ||
-      !password.getValue() ||
-      (action === "Registration" && !name)
-    ) {
+    if (!email || !password || (action === "Registration" && !name)) {
       return;
     }
 
     const endpoint = action === "Registration" ? "/user" : "/session";
     const body: { [key: string]: string } = {
       email,
-      password: password.getValue(),
+      password,
     };
     // Add name to the body if the action is Registration (not Login)
     if (action === "Registration") {
@@ -116,8 +110,7 @@ const LoginScreen = () => {
           </div>
           <div
             className={
-              "input" +
-              (validationOn && !password.getValue() ? " validation" : "")
+              "input" + (validationOn && !password ? " validation" : "")
             }
           >
             <img className="password-icon" src={PasswordIcon} alt="" />


### PR DESCRIPTION
<!-- Please remove the line that does not fit. -->
<!-- Please also enter the respective issue ID after the #. -->
<!-- E.g.: This issue closes #1. -->
This issue closes #32 .

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->
The PasswordWidget was created as a React component to provide in-place feedback for paswword strenght . The Widget was integrated into the LoginScreen with a "handlePasswordChange" method. Also the LoginScreen now uses the Password Value Type that was introduced in issue #26 

## How can this be tested?

By typing different passwords during account creation.

## Screenshots
On login or if no character is typed: it wont show the password strength:
![image](https://github.com/user-attachments/assets/64fb822d-24bf-4cf7-81e1-586a1caeea78)
Otherwise it shows password strength on the right:
![image](https://github.com/user-attachments/assets/0a560b67-1df5-4ef7-8140-3c38fc9f1a58)
![image](https://github.com/user-attachments/assets/f3d795fa-8fc6-4066-a0af-4f3504020bdc)



<!-- If no UI changes were made, please state that here. -->

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules 
**There could be issues when merging issue #34 and #33 because they also change the LoginPage**
- [ ] I have lowered the linter errors. Before: \<NUMBER>. After: \<NUMBER>

