### PR TITLE
fix: Fix frontend docker build not updating files on restart

### DIFF
--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -16,9 +16,8 @@ COPY server/package*.json ./server/
 # Install dependencies
 RUN npm install
 
-# Copy source code (client needs server for type imports)
+# Copy source code
 COPY client ./client
-COPY server ./server
 
 # Build client
 WORKDIR /app/client
@@ -27,9 +26,8 @@ RUN npm run build
 # Production stage - minimal container with just the built files
 FROM alpine:latest
 
-# Copy built files
-COPY --from=builder /app/client/dist /dist
+# Copy built files to source directory (will be synced to volume on startup)
+COPY --from=builder /app/client/dist /dist-source
 
-# This container just holds the files in a volume
-# It will exit immediately, which is expected
-ENTRYPOINT ["/bin/true"]
+# Sync files from source to volume mount on every container start
+ENTRYPOINT ["/bin/sh", "-c", "cp -r /dist-source/* /dist/ && echo 'Client files synced' && exit 0"]


### PR DESCRIPTION
This PR fixes that rebuilding the docker compose setup does not refresh frontend files correctly. In addition, it removes the copy of server code because the dependency of client and server was removed in #74. 