### PR TITLE
fix missing initialization of tables in generateMockData

### DIFF
--- a/server/src/scripts/generateMockData.ts
+++ b/server/src/scripts/generateMockData.ts
@@ -8,14 +8,7 @@ import { initializeDB } from '../databaseInitializer';
  * Creates a semester with students, courses, projects,
  * and happiness ratings for past sprints.
  */
-async function generateMockData(dbPath: string = './server/happyGoLucky.db', deleteOnly: boolean = false) {
-  console.log(`Connecting to database at: ${dbPath}`);
-
-  const db = await open({
-    filename: dbPath,
-    driver: sqlite3.Database,
-  });
-
+async function generateMockData(db: Database, deleteOnly: boolean = false) {
   try {
     console.log('Starting mock data generation...\n');
 


### PR DESCRIPTION
<!-- Please remove the line that does not fit. -->
<!-- Please also enter the respective issue ID after the #. -->
<!-- E.g.: This issue closes #1. -->
This issue closes #89

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->
This PR adds a database initialization step in the generateMockData script before inserting the actual mock table entries. 
Previous to this fix, intializDB was not called in this script, i.e. running this without ever calling `npm run dev` first resulted in an error.

After clean-build or deletion of database file any sequence of dev/generate-mockdata/delete-mockdata should run without any errors.


## How can this be tested?

<!-- Please describe the manual tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. --> 
After doing a clean-build or deleting databse this can be tested by running dev, generate-mockdata, delete-mockdata in any arbitrary sequence --> no error should be observed


## Screenshots

<!-- If you made changes to the frontend, please add screenshots here. -->
<!-- Ideally make before and after screenshots. -->
<!-- Don't forget to add descriptions to the screenshots. -->

<!-- If no UI changes were made, please state that here. -->
no UI changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have lowered the linter errors. Before: 0. After: 0

