### PR TITLE
WIP #96: Add password visibility toggle

### DIFF
--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -3,10 +3,11 @@ import React from "react";
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  rightIcon?: React.ReactNode;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ label, error, className = "", ...props }, ref) => {
+  ({ label, error, rightIcon, className = "", ...props }, ref) => {
     return (
       <div className="space-y-1">
         {label && (
@@ -14,19 +15,26 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             {label}
           </label>
         )}
-        <input
-          ref={ref}
-          className={`box-border w-full rounded-md border border-slate-300 bg-white px-4 py-3 text-slate-900 transition-colors placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 disabled:bg-gray-100 disabled:text-gray-500 ${className}`}
-          {...props}
-        />
-        {error && (
-          <p className="text-sm text-error">{error}</p>
-        )}
+
+        <div className="relative">
+          <input
+            ref={ref}
+            {...props}
+            className={`box-border w-full rounded-md border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder:text-slate-400 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20 pr-12 ${className}`}
+          />
+
+          {rightIcon && (
+            <div className="absolute right-3 inset-y-0 flex items-center">
+              {rightIcon}
+            </div>
+          )}
+        </div>
+
+        {error && <p className="text-sm text-error">{error}</p>}
       </div>
     );
   }
 );
 
 Input.displayName = "Input";
-
 export default Input;

--- a/client/src/components/common/PasswordInput.tsx
+++ b/client/src/components/common/PasswordInput.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import Input from "./Input";
+
+const PasswordInput: React.FC<
+  React.InputHTMLAttributes<HTMLInputElement>
+> = ({ value, ...props }) => {
+  const [show, setShow] = React.useState(false);
+
+  const hasValue = typeof value === "string" && value.length > 0;
+
+  return (
+    <Input
+      {...props}
+      value={value}
+      type={show ? "text" : "password"}
+      rightIcon={
+        hasValue ? (
+          <button
+            type="button"
+            onClick={() => setShow((prev) => !prev)}
+            tabIndex={-1}
+            className="
+              bg-transparent
+              border-0
+              p-0
+              text-sm
+              font-medium
+              text-blue-600
+              hover:text-blue-700
+              focus:outline-none
+              focus:ring-0
+              select-none
+            "
+          >
+            {show ? "Hide" : "Show"}
+          </button>
+        ) : null
+      }
+    />
+  );
+};
+
+export default PasswordInput;

--- a/client/src/components/common/PasswordWidget.tsx
+++ b/client/src/components/common/PasswordWidget.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Input from "./Input";
+import PasswordInput from "./PasswordInput";
 
 const containsLowerAndUpperCase = (value: string): boolean =>
   /(?=.*[a-z])(?=.*[A-Z])/.test(value);
@@ -8,23 +8,13 @@ const containsSpecialCharacter = (value: string): boolean =>
   /[!@#$%^&*(),.?":{}|<>]/.test(value);
 
 const calculatePasswordStrength = (value: string): number => {
-  if (value.length < 8) {
-    return 1;
-  }
+  if (value.length < 8) return 1;
 
   let strength = 1;
-  if (containsLowerAndUpperCase(value)) {
-    strength++;
-  }
-  if (containsNumber(value)) {
-    strength++;
-  }
-  if (containsSpecialCharacter(value)) {
-    strength++;
-  }
-  if (value.length >= 12) {
-    strength++;
-  }
+  if (containsLowerAndUpperCase(value)) strength++;
+  if (containsNumber(value)) strength++;
+  if (containsSpecialCharacter(value)) strength++;
+  if (value.length >= 12) strength++;
   return strength;
 };
 
@@ -61,12 +51,12 @@ const PasswordWidget: React.FC<PasswordWidgetProps> = ({
 
   return (
     <div className="space-y-2">
-      <Input
-        type="password"
+      <PasswordInput
         placeholder="Please enter your password"
         value={password}
         onChange={(e) => onPasswordChange(e.target.value)}
       />
+
       {action === "Registration" && password !== "" && (
         <div className="flex items-center gap-2 text-sm">
           <span className="text-slate-700">Password Strength:</span>


### PR DESCRIPTION
## This PR adds a password visibility toggle to improve the user experience when entering passwords.

#96

**The changes include:**

- Extending the common `Input` component to support inline icons
- Introducing a reusable `PasswordInput` component with show/hide functionality
- Updating `PasswordWidget` to use the new password input
- Preserving existing password strength logic

This makes password entry more user-friendly and aligns the UI with modern form design practices

## How can this be tested?

1. Run the application locally using `npm run dev`
2. Navigate to the Login or Sign Up page
3. Enter a password in the password field
4. Click the "Show"/"Hide" toggle to verify that the password visibility changes correctly
5. Confirm that password strength feedback still behaves as expected

## Screenshots
### Log-in
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/4ed97f1c-af48-4903-9d6c-a2e17cd344b6" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/8269947b-8bcf-4031-82a3-19a425ad257a" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/d6385c61-fad1-40a1-ad81-399ec6e173aa" width="250"/></td>
  </tr>
</table>

### Sign-up
<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ba9ab3dc-3012-4b12-9d21-7ca23b787085" width="250"/></td>
    <td><img src="https://github.com/user-attachments/assets/d5eb5af9-122a-4f87-b97f-ee69170ff3f7" width="245"/></td>
    <td><img src="https://github.com/user-attachments/assets/5b8ae115-1c5c-46ee-aac8-dc5f132132a1" width="240"/></td>
  </tr>
</table>




**After**
## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have lowered the linter errors. Before: \<NUMBER>. After: \<NUMBER>

