### PR TITLE
Rename mini-meco_mini-meco-db container to happy-go-lucky-db - Subitha Murugesan

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -46,7 +46,7 @@ Internet → Caddy (port 80/443)
 
 | Container | Purpose | Exposed Ports | Volumes |
 |-----------|---------|---------------|---------|
-| `server` | Backend API | None (internal only) | `mini-meco_mini-meco-db` (database) |
+| `server` | Backend API | None (internal only) | `happy-go-lucky-db` (database) |
 | `client` | Builds frontend | None (exits after build) | `client-dist` (build output) |
 | `caddy` | Web server & reverse proxy | 80, 443 | `client-dist`, `caddy-data`, `caddy-config`, `Caddyfile` |
 
@@ -142,7 +142,7 @@ This will:
 - Build the frontend and store static files in a volume
 - Start Caddy to serve frontend and proxy API requests
 - Create four Docker volumes:
-  - `mini-meco_mini-meco-db`: SQLite database
+  - `happy-go-lucky-db`: SQLite database
   - `client-dist`: Frontend static files
   - `caddy-data`: Caddy certificates and data
   - `caddy-config`: Caddy configuration
@@ -301,7 +301,7 @@ echo "Backup completed: $BACKUP_DIR/backup-$(date +%Y%m%d-%H%M%S).db"
 
 2. **Copy backup to volume:**
    ```bash
-   docker run --rm -v mini-meco_mini-meco-db:/app/server/data -v $(pwd):/backup alpine \
+   docker run --rm -v happy-go-lucky-db:/app/server/data -v $(pwd):/backup alpine \
      cp /backup/backup-YYYYMMDD-HHMMSS.db /app/server/data/myDatabase.db
    ```
 
@@ -329,10 +329,10 @@ sqlite3 myDatabase.db
 
 ```bash
 # Show volume details
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 
 # Show volume location on host
-docker volume inspect mini-meco_mini-meco-db | grep Mountpoint
+docker volume inspect happy-go-lucky-db | grep Mountpoint
 ```
 
 ---
@@ -509,10 +509,10 @@ docker compose exec server sh -c "cd /app/server && ls -la"
 
 ```bash
 # List volumes
-docker volume ls | grep mini-meco
+docker volume ls | grep happy-go-lucky-db
 
 # Inspect volumes
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 docker volume inspect caddy-data
 docker volume inspect client-dist
 
@@ -632,10 +632,10 @@ curl -I http://localhost/api/user
 **Database not persisting:**
 ```bash
 # Verify volume exists
-docker volume ls | grep mini-meco_mini-meco-db
+docker volume ls | grep happy-go-lucky-db
 
 # Inspect volume
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 
 # Check database file
 docker compose exec server ls -la /app/server/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       EMAIL_USER_FAU: ${EMAIL_USER_FAU}
       EMAIL_PASS_FAU: ${EMAIL_PASS_FAU}
     volumes:
-      - mini-meco-db:/app/server/data
+      - happy-go-lucky-db:/app/server/data
     restart: unless-stopped
     networks:
       - app-network
@@ -53,7 +53,8 @@ services:
     restart: "no"
 
 volumes:
-  mini-meco-db:
+  happy-go-lucky-db:
+    name: happy-go-lucky-db
   caddy-data:
   caddy-config:
   client-dist:


### PR DESCRIPTION
I completed the issue #93 - Ready for review @georg-schwarz

This issue closes  #93 
This issue is part of #93 

**<!-- Please include a summary of the changes and the related issue. -->**

#93 - This change renames the Docker container from mini-meco_mini-meco-db to happy-go-lucky-db to align the container naming with the project name and improve clarity when working with Docker resources.

**<!-- Please also include relevant motivation and context. -->**
#93 The previous container name was inherited from an earlier setup and did not reflect the current project. Renaming the container:
Makes Docker containers easier to identify and reduces confusion when multiple containers are running locally

**## How can this be tested?**
<!-- Please describe the manual tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. --> 

#93 Pull this branch
Rebuild and start the containers:
docker compose down
docker compose up --build
To Verify that: The database container is named happy-go-lucky-db

**## Checklist**

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have lowered the linter errors. Before: \<NUMBER>. After: \<NUMBER>


