### PR TITLE
Rename Docker volume from mini-meco-db to happy-go-lucky-db in deployment documentation and docker-compose configuration

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -46,7 +46,7 @@ Internet → Caddy (port 80/443)
 
 | Container | Purpose | Exposed Ports | Volumes |
 |-----------|---------|---------------|---------|
-| `server` | Backend API | None (internal only) | `mini-meco_mini-meco-db` (database) |
+| `server` | Backend API | None (internal only) | `happy-go-lucky-db` (database) |
 | `client` | Builds frontend | None (exits after build) | `client-dist` (build output) |
 | `caddy` | Web server & reverse proxy | 80, 443 | `client-dist`, `caddy-data`, `caddy-config`, `Caddyfile` |
 
@@ -142,7 +142,7 @@ This will:
 - Build the frontend and store static files in a volume
 - Start Caddy to serve frontend and proxy API requests
 - Create four Docker volumes:
-  - `mini-meco_mini-meco-db`: SQLite database
+  - `happy-go-lucky-db`: SQLite database
   - `client-dist`: Frontend static files
   - `caddy-data`: Caddy certificates and data
   - `caddy-config`: Caddy configuration
@@ -301,7 +301,7 @@ echo "Backup completed: $BACKUP_DIR/backup-$(date +%Y%m%d-%H%M%S).db"
 
 2. **Copy backup to volume:**
    ```bash
-   docker run --rm -v mini-meco_mini-meco-db:/app/server/data -v $(pwd):/backup alpine \
+   docker run --rm -v happy-go-lucky-db:/app/server/data -v $(pwd):/backup alpine \
      cp /backup/backup-YYYYMMDD-HHMMSS.db /app/server/data/myDatabase.db
    ```
 
@@ -329,10 +329,10 @@ sqlite3 myDatabase.db
 
 ```bash
 # Show volume details
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 
 # Show volume location on host
-docker volume inspect mini-meco_mini-meco-db | grep Mountpoint
+docker volume inspect happy-go-lucky-db | grep Mountpoint
 ```
 
 ---
@@ -509,10 +509,10 @@ docker compose exec server sh -c "cd /app/server && ls -la"
 
 ```bash
 # List volumes
-docker volume ls | grep mini-meco
+docker volume ls | grep happy-go-lucky
 
 # Inspect volumes
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 docker volume inspect caddy-data
 docker volume inspect client-dist
 
@@ -632,10 +632,10 @@ curl -I http://localhost/api/user
 **Database not persisting:**
 ```bash
 # Verify volume exists
-docker volume ls | grep mini-meco_mini-meco-db
+docker volume ls | grep happy-go-lucky-db
 
 # Inspect volume
-docker volume inspect mini-meco_mini-meco-db
+docker volume inspect happy-go-lucky-db
 
 # Check database file
 docker compose exec server ls -la /app/server/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       EMAIL_USER_FAU: ${EMAIL_USER_FAU}
       EMAIL_PASS_FAU: ${EMAIL_PASS_FAU}
     volumes:
-      - mini-meco-db:/app/server/data
+      - happy-go-lucky-db:/app/server/data
     restart: unless-stopped
     networks:
       - app-network
@@ -53,7 +53,7 @@ services:
     restart: "no"
 
 volumes:
-  mini-meco-db:
+  happy-go-lucky-db:
   caddy-data:
   caddy-config:
   client-dist:


### PR DESCRIPTION
This issue closes #93. @georg-schwarz 

## Summary

Renamed the Docker volume from `mini-meco-db` to `happy-go-lucky-db` to align with the project name and improve consistency across the infrastructure.

### Changes Made:
- Updated `docker-compose.yml`:
  - Renamed volume mount from `mini-meco-db` to `happy-go-lucky-db` in server service
  - Renamed volume definition from `mini-meco-db` to `happy-go-lucky-db`
- Updated `DEPLOYMENT.md`:
  - Updated container details table
  - Updated Docker volumes list
  - Updated backup/restore commands (3 methods)
  - Updated volume inspection commands
  - Updated troubleshooting commands (14 total occurrences)

### Motivation:
The previous name `mini-meco` was a legacy name that doesn't reflect the current project identity. Using `happy-go-lucky-db` makes it immediately clear which project the volume belongs to and maintains consistency with the project name.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have lowered the linter errors. Before: \<NUMBER>. After: \<NUMBER>
