### PR TITLE
refactor: move messages to en catalog

### DIFF
--- a/server/src/Controllers/CourseController.ts
+++ b/server/src/Controllers/CourseController.ts
@@ -7,6 +7,7 @@ import { IllegalArgumentException } from "../Exceptions/IllegalArgumentException
 import { IAppController } from "./IAppController";
 import { ObjectHandler } from "../ObjectHandler";
 import { checkAdmin } from "../Middleware/checkAdmin";
+import { msgKey, translate } from "../Resources/i18n";
 
 /**
  * Controller for handling course-related HTTP requests.
@@ -62,7 +63,7 @@ export class CourseController implements IAppController {
       if (!courseName || typeof courseName !== "string") {
         res.status(400).json({
           success: false,
-          message: "Course name is required and must be a string",
+          message: translate(req, msgKey.course.courseNameRequiredString),
         });
         return;
       }
@@ -70,7 +71,7 @@ export class CourseController implements IAppController {
       if (termId === undefined || termId === null) {
         res.status(400).json({
           success: false,
-          message: "Term ID is required",
+          message: translate(req, msgKey.course.termIdRequired),
         });
         return;
       }
@@ -79,7 +80,7 @@ export class CourseController implements IAppController {
       if (isNaN(id)) {
         res.status(400).json({
           success: false,
-          message: "Term ID must be a valid number",
+          message: translate(req, msgKey.course.termIdMustBeValidNumber),
         });
         return;
       }
@@ -88,7 +89,7 @@ export class CourseController implements IAppController {
 
       res.status(201).json({
         success: true,
-        message: "Course created successfully",
+        message: translate(req, msgKey.course.courseCreatedSuccessfully),
         data: course,
       });
     } catch (error) {
@@ -102,16 +103,20 @@ export class CourseController implements IAppController {
       const courseId = parseInt(id);
 
       if (isNaN(courseId)) {
-        res
-          .status(400)
-          .json({ success: false, message: "Course ID must be an integer" });
+        res.status(400).json({
+          success: false,
+          message: translate(req, msgKey.course.courseIdMustBeInteger),
+        });
         return;
       }
 
       const course = await this.cm.readCourse(courseId);
 
       if (!course) {
-        res.status(404).json({ success: false, message: "Course not found" });
+        res.status(404).json({
+          success: false,
+          message: translate(req, msgKey.course.courseNotFound),
+        });
         return;
       }
 
@@ -129,7 +134,7 @@ export class CourseController implements IAppController {
     try {
       res.status(501).json({
         success: false,
-        message: "Course delete not implemented yet",
+        message: translate(req, msgKey.course.courseDeleteNotImplementedYet),
       });
     } catch (error) {
       this.handleError(res, error as Exception);
@@ -143,7 +148,7 @@ export class CourseController implements IAppController {
       if (isNaN(courseId)) {
         res.status(400).json({
           success: false,
-          message: "Course ID must be a valid number"
+          message: translate(req, msgKey.course.courseIdMustBeValidNumber),
         });
         return;
       }
@@ -153,14 +158,14 @@ export class CourseController implements IAppController {
       if (!deleted) {
         res.status(404).json({
           success: false,
-          message: "Course not found"
+          message: translate(req, msgKey.course.courseNotFound),
         });
         return;
       }
 
       res.status(200).json({
         success: true,
-        message: "Course deleted successfully",
+        message: translate(req, msgKey.course.courseDeletedSuccessfully),
       });
     } catch (error) {
       this.handleError(res, error as Exception);
@@ -172,7 +177,7 @@ export class CourseController implements IAppController {
     try {
       res.status(501).json({
         success: false,
-        message: "User courses not implemented yet",
+        message: translate(req, msgKey.course.userCoursesNotImplementedYet),
       });
     } catch (error) {
       this.handleError(res, error as Exception);
@@ -188,7 +193,7 @@ export class CourseController implements IAppController {
       if (courseId === undefined || courseId === null) {
         res.status(400).json({
           success: false,
-          message: "Course ID is required",
+          message: translate(req, msgKey.course.courseIdRequired),
         });
         return;
       }
@@ -198,7 +203,7 @@ export class CourseController implements IAppController {
       if (isNaN(id)) {
         res.status(400).json({
           success: false,
-          message: "Invalid course ID format",
+          message: translate(req, msgKey.course.invalidCourseIdFormat),
         });
         return;
       }
@@ -208,7 +213,7 @@ export class CourseController implements IAppController {
       // console.log("[CONTROLLER] addProject: ", proj.getName());
       res.status(201).json({
         success: true,
-        message: "Project added successfully",
+        message: translate(req, msgKey.course.projectAddedSuccessfully),
         data: {
           id: proj.getId(),
           projectName: proj.getName(),
@@ -225,25 +230,37 @@ export class CourseController implements IAppController {
       const { courseId, userEmail } = req.query;
 
       if (!courseId || typeof courseId !== 'string') {
-        res.status(400).json({ success: false, message: "Course ID is required" });
+        res.status(400).json({
+          success: false,
+          message: translate(req, msgKey.course.courseIdRequired),
+        });
         return;
       }
 
       const id = parseInt(courseId);
       if (isNaN(id)) {
-        res.status(400).json({ success: false, message: "Invalid course ID" });
+        res.status(400).json({
+          success: false,
+          message: translate(req, msgKey.course.invalidCourseId),
+        });
         return;
       }
 
       const course = await this.cm.readCourse(id);
       if (!course) {
-        res.status(404).json({ success: false, message: "Course not found" });
+        res.status(404).json({
+          success: false,
+          message: translate(req, msgKey.course.courseNotFound),
+        });
         return;
       }
 
       const projects = await this.cm.getProjectsForCourse(course);
       if (!projects) {
-        res.status(404).json({ success: false, message: "Course projects not found" });
+        res.status(404).json({
+          success: false,
+          message: translate(req, msgKey.course.courseProjectsNotFound),
+        });
         return;
       }
 
@@ -299,7 +316,7 @@ export class CourseController implements IAppController {
       if (isNaN(projectId)) {
         res.status(400).json({
           success: false,
-          message: "Project ID must be a valid number"
+          message: translate(req, msgKey.course.projectIdMustBeValidNumber),
         });
         return;
       }
@@ -307,7 +324,7 @@ export class CourseController implements IAppController {
       if (!projectName || typeof projectName !== "string") {
         res.status(400).json({
           success: false,
-          message: "Project name is required and must be a string"
+          message: translate(req, msgKey.course.projectNameRequiredString),
         });
         return;
       }
@@ -317,14 +334,14 @@ export class CourseController implements IAppController {
       if (!updatedProject) {
         res.status(404).json({
           success: false,
-          message: "Project not found"
+          message: translate(req, msgKey.course.projectNotFound),
         });
         return;
       }
 
       res.status(200).json({
         success: true,
-        message: "Project updated successfully",
+        message: translate(req, msgKey.course.projectUpdatedSuccessfully),
         data: {
           id: updatedProject.getId(),
           projectName: updatedProject.getName(),
@@ -343,7 +360,7 @@ export class CourseController implements IAppController {
       if (isNaN(projectId)) {
         res.status(400).json({
           success: false,
-          message: "Project ID must be a valid number"
+          message: translate(req, msgKey.course.projectIdMustBeValidNumber),
         });
         return;
       }
@@ -353,14 +370,14 @@ export class CourseController implements IAppController {
       if (!deleted) {
         res.status(404).json({
           success: false,
-          message: "Project not found"
+          message: translate(req, msgKey.course.projectNotFound),
         });
         return;
       }
 
       res.status(200).json({
         success: true,
-        message: "Project deleted successfully",
+        message: translate(req, msgKey.course.projectDeletedSuccessfully),
       });
     } catch (error) {
       this.handleError(res, error as Exception);
@@ -375,7 +392,7 @@ export class CourseController implements IAppController {
       if (isNaN(courseId)) {
         res.status(400).json({
           success: false,
-          message: "Course ID must be a valid number"
+          message: translate(req, msgKey.course.courseIdMustBeValidNumber),
         });
         return;
       }
@@ -383,7 +400,7 @@ export class CourseController implements IAppController {
       if (!startDate || !endDate) {
         res.status(400).json({
           success: false,
-          message: "Start date and end date are required"
+          message: translate(req, msgKey.course.startAndEndDateRequired),
         });
         return;
       }
@@ -397,7 +414,7 @@ export class CourseController implements IAppController {
 
       res.status(200).json({
         success: true,
-        message: "Schedule saved successfully",
+        message: translate(req, msgKey.course.scheduleSavedSuccessfully),
         data: {
           id: schedule.getId(),
           startDate: schedule.getStartDate(),
@@ -417,7 +434,7 @@ export class CourseController implements IAppController {
       if (isNaN(courseId)) {
         res.status(400).json({
           success: false,
-          message: "Course ID must be a valid number"
+          message: translate(req, msgKey.course.courseIdMustBeValidNumber),
         });
         return;
       }
@@ -427,7 +444,7 @@ export class CourseController implements IAppController {
       if (!schedule) {
         res.status(404).json({
           success: false,
-          message: "Schedule not found for this course"
+          message: translate(req, msgKey.course.scheduleNotFoundForCourse),
         });
         return;
       }
@@ -470,7 +487,7 @@ export class CourseController implements IAppController {
     } else if (error.name === "MethodFailedException") {
       res.status(500).json({
         success: false,
-        message: "An error occurred while processing your request",
+        message: translate(msgKey.common.requestProcessingError),
       });
       return;
     } else {
@@ -479,14 +496,14 @@ export class CourseController implements IAppController {
       if (msg.includes('Unknown Course Name!') || msg.includes('User not found')) {
         res.status(404).json({
           success: false,
-          message: "Resource not found",
+          message: translate(msgKey.common.resourceNotFound),
         });
         return;
       }
 
       res.status(500).json({
         success: false,
-        message: "Internal server error",
+        message: translate(msgKey.common.internalServerError),
       });
     }
   }

--- a/server/src/Controllers/LegacyController.ts
+++ b/server/src/Controllers/LegacyController.ts
@@ -2,6 +2,7 @@ import { Application, Request, Response } from "express";
 import { Database } from "sqlite";
 import { DatabaseHelpers } from "../Models/DatabaseHelpers";
 import { IAppController } from "./IAppController";
+import { msgKey, translate } from "../Resources/i18n";
 
 /**
  * Controller for handling legacy HTTP endpoints.
@@ -23,10 +24,10 @@ export class LegacyController implements IAppController {
     const { userEmail, URL, projectName } = req.body;
 
     if (!URL) {
-      res.status(400).json({ message: "Please fill in URL!" });
+      res.status(400).json({ message: translate(req, msgKey.common.pleaseFillInUrl) });
       return;
     } else if (!URL.includes("git")) {
-      res.status(400).json({ message: "Invalid URL" });
+      res.status(400).json({ message: translate(req, msgKey.common.invalidUrl) });
       return;
     }
 
@@ -38,10 +39,10 @@ export class LegacyController implements IAppController {
         `UPDATE user_projects SET url = ? WHERE userId = ? AND projectId = ?`,
         [URL, userId, projectId]
       );
-      res.status(200).json({ message: "URL added successfully" });
+      res.status(200).json({ message: translate(req, msgKey.common.urlAddedSuccessfully) });
     } catch (error) {
       console.error("Error adding URL:", error);
-      res.status(500).json({ message: "Failed to add URL", error });
+      res.status(500).json({ message: translate(req, msgKey.common.failedToAddUrl), error });
     }
   }
 
@@ -54,7 +55,7 @@ export class LegacyController implements IAppController {
         projectId = await DatabaseHelpers.getProjectIdFromName(this.db, projectName);
       } catch (error) {
         if (error instanceof Error && error.message.includes("Unknown Course Name!")) {
-          res.status(404).json({ message: "Project not found" });
+          res.status(404).json({ message: translate(req, msgKey.common.projectNotFound) });
           return;
         }
         throw error;
@@ -66,7 +67,7 @@ export class LegacyController implements IAppController {
         [userId, projectId]
       );
       if (!isMember) {
-        res.status(400).json({ message: "You are not a member of this project" });
+        res.status(400).json({ message: translate(req, msgKey.common.notMemberOfProject) });
         return;
       }
       await this.db.run("DELETE FROM user_projects WHERE userId = ? AND projectId = ?", [
@@ -74,10 +75,10 @@ export class LegacyController implements IAppController {
         projectId,
       ]);
 
-      res.status(200).json({ message: "Left project successfully" });
+      res.status(200).json({ message: translate(req, msgKey.common.leftProjectSuccessfully) });
     } catch (error) {
       console.error("Error during leaving project:", error);
-      res.status(500).json({ message: "Failed to leave project", error });
+      res.status(500).json({ message: translate(req, msgKey.common.failedToLeaveProject), error });
     }
   }
 }

--- a/server/src/Controllers/ProjectController.ts
+++ b/server/src/Controllers/ProjectController.ts
@@ -4,6 +4,7 @@ import { DatabaseHelpers } from "../Models/DatabaseHelpers";
 import { Email } from "../ValueTypes/Email";
 import { IAppController } from "./IAppController";
 import { IEmailService } from "../Services/IEmailService";
+import { msgKey, translate } from "../Resources/i18n";
 
 /**
  * Controller for handling project-related HTTP requests.
@@ -43,7 +44,7 @@ export class ProjectController implements IAppController {
     const { courseName } = req.query;
 
     if (!courseName) {
-      res.status(400).json({ message: "Course id is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.courseIdIsRequired) });
       return;
     }
 
@@ -53,7 +54,7 @@ export class ProjectController implements IAppController {
         courseId = await DatabaseHelpers.getCourseIdFromName(this.db, courseName.toString());
       } catch (error) {
         if (error instanceof Error && error.message.includes("Unknown Course Name!")) {
-          res.status(404).json({ message: "Course not found" });
+          res.status(404).json({ message: translate(req, msgKey.common.courseNotFound) });
           return;
         }
         throw error;
@@ -65,7 +66,10 @@ export class ProjectController implements IAppController {
       console.error("Error during project retrieval:", error);
       res
         .status(500)
-        .json({ message: `Failed to retrieve projects for course ${courseName}`, error });
+        .json({
+          message: translate(req, msgKey.project.failedToRetrieveProjectsForCourse, courseName),
+          error,
+        });
     }
   }
 
@@ -73,7 +77,9 @@ export class ProjectController implements IAppController {
     const { newCourseName, projectName, newProjectName } = req.body;
 
     if (!newCourseName || !newProjectName) {
-      res.status(400).json({ message: "Please fill in project group name and project name" });
+      res
+        .status(400)
+        .json({ message: translate(req, msgKey.project.fillInProjectGroupAndProjectName) });
       return;
     }
 
@@ -85,10 +91,10 @@ export class ProjectController implements IAppController {
         newCourseId,
         projectId,
       ]);
-      res.status(201).json({ message: "Project edited successfully" });
+      res.status(201).json({ message: translate(req, msgKey.project.projectEditedSuccessfully) });
     } catch (error) {
       console.error("Error during project edition:", error);
-      res.status(500).json({ message: "Project edition failed", error });
+      res.status(500).json({ message: translate(req, msgKey.project.projectEditionFailed), error });
     }
   }
 
@@ -96,7 +102,7 @@ export class ProjectController implements IAppController {
     const { projectName } = req.query;
 
     if (!projectName) {
-      res.status(400).json({ message: "Project name is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.projectNameIsRequired) });
       return;
     }
 
@@ -111,11 +117,13 @@ export class ProjectController implements IAppController {
       if (course) {
         res.json(course);
       } else {
-        res.status(404).json({ message: "Course not found for this project" });
+        res
+          .status(404)
+          .json({ message: translate(req, msgKey.project.courseNotFoundForProject) });
       }
     } catch (error) {
       console.error("Error fetching course for project:", error);
-      res.status(500).json({ message: "Failed to fetch course", error });
+      res.status(500).json({ message: translate(req, msgKey.project.failedToFetchCourse), error });
     }
   }
 
@@ -124,18 +132,20 @@ export class ProjectController implements IAppController {
 
     let userEmail: Email;
     if (!req.query.email || typeof req.query.email !== "string") {
-      res.status(400).json({ message: "User email is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.userEmailIsRequired) });
       return;
     }
     try {
       userEmail = new Email(req.query.email as string);
     } catch {
-      res.status(400).json({ message: "Invalid email address" });
+      res.status(400).json({ message: translate(req, msgKey.common.invalidEmailAddress) });
       return;
     }
 
     if (!projectName) {
-      res.status(400).json({ message: "Project name and user email are required" });
+      res
+        .status(400)
+        .json({ message: translate(req, msgKey.project.projectNameAndUserEmailRequired) });
       return;
     }
 
@@ -150,13 +160,15 @@ export class ProjectController implements IAppController {
       );
 
       if (!role) {
-        res.status(404).json({ message: "Role not found" });
+        res.status(404).json({ message: translate(req, msgKey.project.roleNotFound) });
         return;
       }
       res.json({ role: role.role });
     } catch (error) {
       console.error("Error retrieving project role", error);
-      res.status(500).json({ message: "Failed to retrieve project role", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToRetrieveProjectRole), error });
     }
   }
 
@@ -165,18 +177,18 @@ export class ProjectController implements IAppController {
 
     let memberEmail: Email;
     if (!memberEmailStr || typeof memberEmailStr !== "string") {
-      res.status(400).json({ message: "User email is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.userEmailIsRequired) });
       return;
     }
     try {
       memberEmail = new Email(memberEmailStr);
     } catch {
-      res.status(400).json({ message: "Invalid email address" });
+      res.status(400).json({ message: translate(req, msgKey.common.invalidEmailAddress) });
       return;
     }
 
     if (!memberRole) {
-      res.status(400).json({ message: "Please fill in your role" });
+      res.status(400).json({ message: translate(req, msgKey.project.fillInYourRole) });
       return;
     }
 
@@ -186,7 +198,7 @@ export class ProjectController implements IAppController {
         projectId = await DatabaseHelpers.getProjectIdFromName(this.db, projectName);
       } catch (error) {
         if (error instanceof Error && error.message.includes("Unknown Project Name!")) {
-          res.status(404).json({ message: "Project not found" });
+          res.status(404).json({ message: translate(req, msgKey.common.projectNotFound) });
           return;
         }
         throw error;
@@ -198,7 +210,7 @@ export class ProjectController implements IAppController {
         [userId, projectId]
       );
       if (isMember) {
-        res.status(400).json({ message: "You have already joined this project" });
+        res.status(400).json({ message: translate(req, msgKey.project.alreadyJoinedProject) });
         return;
       }
 
@@ -207,10 +219,12 @@ export class ProjectController implements IAppController {
         projectId,
         memberRole,
       ]);
-      res.status(201).json({ message: "Joined project successfully" });
+      res
+        .status(201)
+        .json({ message: translate(req, msgKey.project.joinedProjectSuccessfully) });
     } catch (error) {
       console.error("Error during joining project:", error);
-      res.status(500).json({ message: "Failed to join project", error });
+      res.status(500).json({ message: translate(req, msgKey.project.failedToJoinProject), error });
     }
   }
 
@@ -223,7 +237,7 @@ export class ProjectController implements IAppController {
         projectId = await DatabaseHelpers.getProjectIdFromName(this.db, projectName);
       } catch (error) {
         if (error instanceof Error && error.message.includes("Unknown Project Name!")) {
-          res.status(404).json({ message: "Project not found" });
+          res.status(404).json({ message: translate(req, msgKey.common.projectNotFound) });
           return;
         }
         throw error;
@@ -235,7 +249,7 @@ export class ProjectController implements IAppController {
         [userId, projectId]
       );
       if (!isMember) {
-        res.status(400).json({ message: "You are not a member of this project" });
+        res.status(400).json({ message: translate(req, msgKey.project.notMemberOfProject) });
         return;
       }
       await this.db.run("DELETE FROM user_projects WHERE userId = ? AND projectId = ?", [
@@ -243,23 +257,23 @@ export class ProjectController implements IAppController {
         projectId,
       ]);
 
-      res.status(200).json({ message: "Left project successfully" });
+      res.status(200).json({ message: translate(req, msgKey.project.leftProjectSuccessfully) });
     } catch (error) {
       console.error("Error during leaving project:", error);
-      res.status(500).json({ message: "Failed to leave project", error });
+      res.status(500).json({ message: translate(req, msgKey.project.failedToLeaveProject), error });
     }
   }
 
   async getUserProjects(req: Request, res: Response): Promise<void> {
     let userEmail: Email;
     if (!req.query.userEmail || typeof req.query.userEmail !== "string") {
-      res.status(400).json({ message: "User email is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.userEmailIsRequired) });
       return;
     }
     try {
       userEmail = new Email(req.query.userEmail as string);
     } catch {
-      res.status(400).json({ message: "Invalid email address" });
+      res.status(400).json({ message: translate(req, msgKey.common.invalidEmailAddress) });
       return;
     }
 
@@ -275,20 +289,22 @@ export class ProjectController implements IAppController {
       res.json(projects);
     } catch (error) {
       console.error("Error during retrieving user projects:", error);
-      res.status(500).json({ message: "Failed to retrieve user projects", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToRetrieveUserProjects), error });
     }
   }
 
   async getEnrolledCourses(req: Request, res: Response): Promise<void> {
     let userEmail: Email;
     if (!req.query.userEmail || typeof req.query.userEmail !== "string") {
-      res.status(400).json({ message: "User email is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.userEmailIsRequired) });
       return;
     }
     try {
       userEmail = new Email(req.query.userEmail as string);
     } catch {
-      res.status(400).json({ message: "Invalid email address" });
+      res.status(400).json({ message: translate(req, msgKey.common.invalidEmailAddress) });
       return;
     }
 
@@ -305,7 +321,9 @@ export class ProjectController implements IAppController {
       res.json(courses);
     } catch (error) {
       console.error("Error during retrieving courses of user:", error);
-      res.status(500).json({ message: "Failed to retrieve courses of user", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToRetrieveCoursesOfUser), error });
     }
   }
 
@@ -314,7 +332,9 @@ export class ProjectController implements IAppController {
     const timestamp = new Date().toISOString();
 
     if (!submissionDateId || typeof submissionDateId !== 'number') {
-      res.status(400).json({ message: "Submission date ID is required and must be a number" });
+      res
+        .status(400)
+        .json({ message: translate(req, msgKey.project.submissionDateIdRequiredNumber) });
       return;
     }
 
@@ -325,7 +345,7 @@ export class ProjectController implements IAppController {
         [submissionDateId]
       );
       if (!submission) {
-        res.status(404).json({ message: "Submission date not found" });
+        res.status(404).json({ message: translate(req, msgKey.project.submissionDateNotFound) });
         return;
       }
 
@@ -340,7 +360,7 @@ export class ProjectController implements IAppController {
       );
 
       if (!projectId || !userId) {
-        res.status(404).json({ message: "Project or user not found" });
+        res.status(404).json({ message: translate(req, msgKey.project.projectOrUserNotFound) });
         return;
       }
 
@@ -358,10 +378,14 @@ export class ProjectController implements IAppController {
         [projectId.id, userId.id, happiness, submissionDateId, timestamp]
       );
 
-      res.status(200).json({ message: "Happiness updated successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.project.happinessUpdatedSuccessfully) });
     } catch (error) {
       console.error("Error updating happiness:", error);
-      res.status(500).json({ message: "Failed to update happiness", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToUpdateHappiness), error });
     }
   }
 
@@ -380,7 +404,9 @@ export class ProjectController implements IAppController {
       res.json(happinessData);
     } catch (error) {
       console.error("Error fetching happiness data:", error);
-      res.status(500).json({ message: "Failed to fetch happiness data", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToFetchHappinessData), error });
     }
   }
 
@@ -388,7 +414,7 @@ export class ProjectController implements IAppController {
     const { projectName } = req.query;
 
     if (!projectName || typeof projectName !== 'string') {
-      res.status(400).json({ message: "Project name is required" });
+      res.status(400).json({ message: translate(req, msgKey.project.projectNameIsRequired) });
       return;
     }
 
@@ -400,7 +426,7 @@ export class ProjectController implements IAppController {
       );
 
       if (!project) {
-        res.status(404).json({ message: "Project not found" });
+        res.status(404).json({ message: translate(req, msgKey.common.projectNotFound) });
         return;
       }
 
@@ -413,7 +439,7 @@ export class ProjectController implements IAppController {
       );
 
       if (!schedule) {
-        res.status(404).json({ message: "No schedule found for this course" });
+        res.status(404).json({ message: translate(req, msgKey.project.noScheduleFoundForCourse) });
         return;
       }
 
@@ -429,7 +455,9 @@ export class ProjectController implements IAppController {
       );
 
       if (!nextSubmission) {
-        res.status(404).json({ message: "No future submission dates available" });
+        res
+          .status(404)
+          .json({ message: translate(req, msgKey.project.noFutureSubmissionDatesAvailable) });
         return;
       }
 
@@ -440,7 +468,9 @@ export class ProjectController implements IAppController {
       });
     } catch (error) {
       console.error("Error fetching available submissions:", error);
-      res.status(500).json({ message: "Failed to fetch available submissions", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToFetchAvailableSubmissions), error });
     }
   }
 
@@ -459,7 +489,7 @@ export class ProjectController implements IAppController {
       console.log(`Found ${members.length} members for project "${projectName}":`, members);
 
       if (members.length === 0) {
-        res.status(400).json({ message: "No members in the project group" });
+        res.status(400).json({ message: translate(req, msgKey.project.noMembersInProjectGroup) });
         return;
       }
 
@@ -467,14 +497,18 @@ export class ProjectController implements IAppController {
 
       await this.emailService.sendEmail(
         recipientEmails,
-        `Standup Update for ${projectName}`,
-        `Standup report from ${userName}\n\nDone: ${doneText}\nPlans: ${plansText}\nChallenges: ${challengesText}`
+        translate(req, msgKey.project.standupEmailSubject, projectName),
+        translate(req, msgKey.project.standupEmailBody, userName, doneText, plansText, challengesText)
       );
 
-      res.status(200).json({ message: "Standup email sent successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.project.standupEmailSentSuccessfully) });
     } catch (error) {
       console.error("Error sending standup email:", error);
-      res.status(500).json({ message: "Failed to send standup email", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.project.failedToSendStandupEmail), error });
     }
   }
 }

--- a/server/src/Controllers/TermController.ts
+++ b/server/src/Controllers/TermController.ts
@@ -7,6 +7,7 @@ import { IllegalArgumentException } from "../Exceptions/IllegalArgumentException
 import { IAppController } from "./IAppController";
 import { ObjectHandler } from "../ObjectHandler";
 import { checkAdmin } from "../Middleware/checkAdmin";
+import { msgKey, translate } from "../Resources/i18n";
 
 /**
  * Controller for handling term-related HTTP requests.
@@ -55,7 +56,7 @@ export class TermController implements IAppController {
       if (!termName || typeof termName !== "string") {
         res.status(400).json({
           success: false,
-          message: "Term name is required and must be a string",
+          message: translate(req, msgKey.term.termNameRequiredString),
         });
         return;
       }
@@ -64,7 +65,7 @@ export class TermController implements IAppController {
 
       res.status(201).json({
         success: true,
-        message: "Term created successfully",
+        message: translate(req, msgKey.term.termCreatedSuccessfully),
         data: term,
       });
     } catch (error) {
@@ -79,7 +80,7 @@ export class TermController implements IAppController {
       if (isNaN(termId)) {
         res.status(400).json({
           success: false,
-          message: "Term ID must be a valid number"
+          message: translate(req, msgKey.term.termIdMustBeValidNumber),
         });
         return;
       }
@@ -89,14 +90,14 @@ export class TermController implements IAppController {
       if (!deleted) {
         res.status(404).json({
           success: false,
-          message: "Term not found"
+          message: translate(req, msgKey.term.termNotFound),
         });
         return;
       }
 
       res.status(200).json({
         success: true,
-        message: "Term deleted successfully",
+        message: translate(req, msgKey.term.termDeletedSuccessfully),
       });
     } catch (error) {
       this.handleError(res, error as Exception);
@@ -110,7 +111,7 @@ export class TermController implements IAppController {
       if (termId === undefined || termId === null) {
         res.status(400).json({
           success: false,
-          message: "Term ID is required",
+          message: translate(req, msgKey.term.termIdRequired),
         });
         return;
       }
@@ -119,7 +120,7 @@ export class TermController implements IAppController {
       if (isNaN(id)) {
         res.status(400).json({
           success: false,
-          message: "Invalid term ID format",
+          message: translate(req, msgKey.term.invalidTermIdFormat),
         });
         return;
       }
@@ -128,7 +129,7 @@ export class TermController implements IAppController {
 
       res.status(201).json({
         success: true,
-        message: "Course added successfully",
+        message: translate(req, msgKey.term.courseAddedSuccessfully),
         data: {
           id: course.getId(),
           courseName: course.getName(),
@@ -145,19 +146,28 @@ export class TermController implements IAppController {
       const { termId } = req.query;
 
       if (!termId || typeof termId !== 'string') {
-        res.status(400).json({ success: false, message: "Term ID is required" });
+        res.status(400).json({
+          success: false,
+          message: translate(req, msgKey.term.termIdRequired),
+        });
         return;
       }
 
       const id = parseInt(termId);
       if (isNaN(id)) {
-        res.status(400).json({ success: false, message: "Invalid term ID" });
+        res.status(400).json({
+          success: false,
+          message: translate(req, msgKey.term.invalidTermId),
+        });
         return;
       }
 
       const term = await this.tm.readTerm(id);
       if (!term) {
-        res.status(404).json({ success: false, message: "Term not found" });
+        res.status(404).json({
+          success: false,
+          message: translate(req, msgKey.term.termNotFound),
+        });
         return;
       }
 
@@ -196,13 +206,13 @@ export class TermController implements IAppController {
     } else if (error.name === "MethodFailedException") {
       res.status(500).json({
         success: false,
-        message: "An error occurred while processing your request",
+        message: translate(msgKey.common.requestProcessingError),
       });
       return;
     } else {
       res.status(500).json({
         success: false,
-        message: "Internal server error",
+        message: translate(msgKey.common.internalServerError),
       });
     }
   }

--- a/server/src/Controllers/UserController.ts
+++ b/server/src/Controllers/UserController.ts
@@ -5,6 +5,7 @@ import { DatabaseHelpers } from "../Models/DatabaseHelpers";
 import { checkOwnership } from "../Middleware/checkOwnership";
 import { IAppController } from "./IAppController";
 import { IEmailService } from "../Services/IEmailService";
+import { msgKey, translate } from "../Resources/i18n";
 
 /**
  * Controller for handling user-related HTTP requests.
@@ -41,11 +42,13 @@ export class UserController implements IAppController {
       if (user) {
         res.json(user);
       } else {
-        res.status(404).json({ message: "User not found" });
+        res.status(404).json({ message: translate(req, msgKey.common.userNotFound) });
       }
     } catch (error) {
       console.error("Error during retrieving user status:", error);
-      res.status(500).json({ message: "Failed to retrieve user status", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToRetrieveUserStatus), error });
     }
   }
 
@@ -57,11 +60,13 @@ export class UserController implements IAppController {
       if (user) {
         res.json(user);
       } else {
-        res.status(404).json({ message: "User not found" });
+        res.status(404).json({ message: translate(req, msgKey.common.userNotFound) });
       }
     } catch (error) {
       console.error("Error during retrieving user status:", error);
-      res.status(500).json({ message: "Failed to retrieve user status", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToRetrieveUserStatus), error });
     }
   }
 
@@ -69,7 +74,7 @@ export class UserController implements IAppController {
     const { userEmail, status } = req.body;
 
     if (!userEmail || !status) {
-      res.status(400).json({ message: "Please provide email and status" });
+      res.status(400).json({ message: translate(req, msgKey.user.provideEmailAndStatus) });
       return;
     }
 
@@ -81,10 +86,14 @@ export class UserController implements IAppController {
 
     try {
       await this.db.run("UPDATE users SET status = ? WHERE email = ?", [status, userEmail]);
-      res.status(200).json({ message: "User status updated successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.user.userStatusUpdatedSuccessfully) });
     } catch (error) {
       console.error("Error during updating user status:", error);
-      res.status(500).json({ message: "Failed to update user status", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToUpdateUserStatus), error });
     }
   }
 
@@ -92,7 +101,7 @@ export class UserController implements IAppController {
     const { status } = req.body;
 
     if (!status) {
-      res.status(400).json({ message: "Status is required" });
+      res.status(400).json({ message: translate(req, msgKey.user.statusIsRequired) });
       return;
     }
 
@@ -103,34 +112,38 @@ export class UserController implements IAppController {
       );
 
       if (result.changes === 0) {
-        res.status(404).json({ message: "No confirmed users found to update" });
+        res
+          .status(404)
+          .json({ message: translate(req, msgKey.user.noConfirmedUsersFoundToUpdate) });
         return;
       }
 
-      res.status(200).json({ message: `All confirmed users have been updated to ${status}` });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.user.allConfirmedUsersUpdatedTo, status) });
     } catch (error) {
       console.error("Error updating confirmed users:", error);
-      res.status(500).json({ message: "Failed to update confirmed users" });
+      res.status(500).json({ message: translate(req, msgKey.user.failedToUpdateConfirmedUsers) });
     }
   }
 
   async changeEmail(req: Request, res: Response): Promise<void> {
     const { newEmail, oldEmail } = req.body;
     if (!newEmail) {
-      res.status(400).json({ message: "Please fill in new email!" });
+      res.status(400).json({ message: translate(req, msgKey.user.fillInNewEmail) });
       return;
     } else if (!newEmail.includes("@")) {
-      res.status(400).json({ message: "Invalid email address" });
+      res.status(400).json({ message: translate(req, msgKey.user.invalidEmailAddress) });
       return;
     }
 
     try {
       const userId = await DatabaseHelpers.getUserIdFromEmail(this.db, oldEmail);
       await this.db.run(`UPDATE users SET email = ? WHERE id = ?`, [newEmail, userId]);
-      res.status(200).json({ message: "Email updated successfully" });
+      res.status(200).json({ message: translate(req, msgKey.user.emailUpdatedSuccessfully) });
     } catch (error) {
       console.error("Error updating email:", error);
-      res.status(500).json({ message: "Failed to update email", error });
+      res.status(500).json({ message: translate(req, msgKey.user.failedToUpdateEmail), error });
     }
   }
 
@@ -138,10 +151,10 @@ export class UserController implements IAppController {
     const { userEmail, password } = req.body;
 
     if (!password) {
-      res.status(400).json({ message: "Please fill in new password!" });
+      res.status(400).json({ message: translate(req, msgKey.user.fillInNewPassword) });
       return;
     } else if (password.length < 8) {
-      res.status(400).json({ message: "Password must be at least 8 characters long" });
+      res.status(400).json({ message: translate(req, msgKey.user.passwordMinLength8) });
       return;
     }
 
@@ -150,10 +163,14 @@ export class UserController implements IAppController {
     try {
       const userId = await DatabaseHelpers.getUserIdFromEmail(this.db, userEmail);
       await this.db.run(`UPDATE users SET password = ? WHERE id = ?`, [hashedPassword, userId]);
-      res.status(200).json({ message: "Password updated successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.user.passwordUpdatedSuccessfully) });
     } catch (error) {
       console.error("Error updating password:", error);
-      res.status(500).json({ message: "Failed to update password", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToUpdatePassword), error });
     }
   }
 
@@ -161,10 +178,10 @@ export class UserController implements IAppController {
     const { userEmail, URL, projectName } = req.body;
 
     if (!URL) {
-      res.status(400).json({ message: "Please fill in URL!" });
+      res.status(400).json({ message: translate(req, msgKey.user.fillInUrl) });
       return;
     } else if (!URL.includes("git")) {
-      res.status(400).json({ message: "Invalid URL" });
+      res.status(400).json({ message: translate(req, msgKey.user.invalidUrl) });
       return;
     }
 
@@ -176,10 +193,10 @@ export class UserController implements IAppController {
         `UPDATE user_projects SET url = ? WHERE userId = ? AND projectId = ?`,
         [URL, userId, projectId]
       );
-      res.status(200).json({ message: "URL added successfully" });
+      res.status(200).json({ message: translate(req, msgKey.user.urlAddedSuccessfully) });
     } catch (error) {
       console.error("Error adding URL:", error);
-      res.status(500).json({ message: "Failed to add URL", error });
+      res.status(500).json({ message: translate(req, msgKey.user.failedToAddUrl), error });
     }
   }
 
@@ -187,7 +204,9 @@ export class UserController implements IAppController {
     const { userEmail, projectName } = req.query;
 
     if (!userEmail || !projectName) {
-      res.status(400).json({ message: "User Email and Project Name are mandatory!" });
+      res
+        .status(400)
+        .json({ message: translate(req, msgKey.user.userEmailAndProjectNameMandatory) });
       return;
     }
 
@@ -202,7 +221,7 @@ export class UserController implements IAppController {
       res.status(200).json({ url });
     } catch (error) {
       console.error("Error fetching URL:", error);
-      res.status(500).json({ message: "Failed to fetch URL", error });
+      res.status(500).json({ message: translate(req, msgKey.user.failedToFetchUrl), error });
     }
   }
 
@@ -210,12 +229,12 @@ export class UserController implements IAppController {
     const { userEmail, newGithubUsername } = req.body;
 
     if (!userEmail) {
-      res.status(400).json({ message: "User email is required!" });
+      res.status(400).json({ message: translate(req, msgKey.user.userEmailRequiredBang) });
       return;
     }
 
     if (!newGithubUsername) {
-      res.status(400).json({ message: "Please fill in GitHub username!" });
+      res.status(400).json({ message: translate(req, msgKey.user.fillInGitHubUsername) });
       return;
     }
 
@@ -225,7 +244,7 @@ export class UserController implements IAppController {
         userId = await DatabaseHelpers.getUserIdFromEmail(this.db, userEmail);
       } catch (error) {
         if (error instanceof Error && error.message.includes("User not found")) {
-          res.status(404).json({ message: "User not found" });
+          res.status(404).json({ message: translate(req, msgKey.common.userNotFound) });
           return;
         }
         throw error;
@@ -235,10 +254,14 @@ export class UserController implements IAppController {
         newGithubUsername,
         userId,
       ]);
-      res.status(200).json({ message: "GitHub username added successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.user.githubUsernameAddedSuccessfully) });
     } catch (error) {
       console.error("Error adding GitHub username:", error);
-      res.status(500).json({ message: "Failed to add GitHub username", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToAddGitHubUsername), error });
     }
   }
 
@@ -246,7 +269,7 @@ export class UserController implements IAppController {
     const { userEmail } = req.query;
 
     if (!userEmail) {
-      res.status(400).json({ message: "User Email is mandatory!" });
+      res.status(400).json({ message: translate(req, msgKey.user.userEmailMandatoryBang) });
       return;
     }
 
@@ -259,7 +282,9 @@ export class UserController implements IAppController {
       res.status(200).json({ githubUsername });
     } catch (error) {
       console.error("Error fetching GitHub username:", error);
-      res.status(500).json({ message: "Failed to fetch GitHub username", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToFetchGitHubUsername), error });
     }
   }
 
@@ -271,11 +296,13 @@ export class UserController implements IAppController {
       if (user) {
         res.json(user);
       } else {
-        res.status(404).json({ message: "User not found" });
+        res.status(404).json({ message: translate(req, msgKey.common.userNotFound) });
       }
     } catch (error) {
       console.error("Error during retrieving user role:", error);
-      res.status(500).json({ message: "Failed to retrieve user role", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToRetrieveUserRole), error });
     }
   }
 
@@ -283,32 +310,36 @@ export class UserController implements IAppController {
     const { email, role } = req.body;
 
     if (!email || !role) {
-      res.status(400).json({ message: "Please provide email and role" });
+      res.status(400).json({ message: translate(req, msgKey.user.provideEmailAndRole) });
       return;
     }
 
     try {
       await this.db.run("UPDATE users SET userRole = ? WHERE email = ?", [role, email]);
-      res.status(200).json({ message: "User role updated successfully" });
+      res
+        .status(200)
+        .json({ message: translate(req, msgKey.user.userRoleUpdatedSuccessfully) });
     } catch (error) {
       console.error("Error during updating user role:", error);
-      res.status(500).json({ message: "Failed to update user role", error });
+      res
+        .status(500)
+        .json({ message: translate(req, msgKey.user.failedToUpdateUserRole), error });
     }
   }
 
   private async sendSuspendedEmail(email: string): Promise<void> {
     await this.emailService.sendEmail(
       email,
-      "Account Suspended",
-      "Your account has been suspended. Please contact the administrator for more information."
+      translate(msgKey.user.accountSuspendedSubject),
+      translate(msgKey.user.accountSuspendedBody)
     );
   }
 
   private async sendRemovedEmail(email: string): Promise<void> {
     await this.emailService.sendEmail(
       email,
-      "Account Removed",
-      "Your account has been removed. Please contact the administrator for more information."
+      translate(msgKey.user.accountRemovedSubject),
+      translate(msgKey.user.accountRemovedBody)
     );
   }
 }

--- a/server/src/Middleware/checkAdmin.ts
+++ b/server/src/Middleware/checkAdmin.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { Database } from "sqlite";
 import jwt from "jsonwebtoken";
 import { ObjectHandler } from "../ObjectHandler";
+import { msgKey, translate } from "../Resources/i18n";
 
 const secret = process.env.JWT_SECRET || "your_jwt_secret";
 
@@ -16,7 +17,9 @@ export function checkAdmin(db: Database) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const token = req.header("Authorization")?.replace("Bearer ", "");
     if (!token) {
-      res.status(401).json({ success: false, message: "Authentication required" });
+      res
+        .status(401)
+        .json({ success: false, message: translate(req, msgKey.common.authenticationRequired) });
       return;
     }
 
@@ -26,17 +29,20 @@ export function checkAdmin(db: Database) {
       const user = await oh.getUser(Number(decoded.id), db);
 
       if (!user) {
-        res.status(404).json({ success: false, message: "User not found" });
+        res.status(404).json({ success: false, message: translate(req, msgKey.common.userNotFound) });
         return;
       }
 
       // Check if user is admin
       if (user.getRole() !== "ADMIN") {
-        res.status(403).json({ success: false, message: "Forbidden: Admin access required" });
+        res.status(403).json({
+          success: false,
+          message: translate(req, msgKey.common.adminAccessRequired),
+        });
         return;
       }
     } catch {
-      res.status(401).json({ success: false, message: "Invalid token" });
+      res.status(401).json({ success: false, message: translate(req, msgKey.common.invalidToken) });
       return;
     }
 

--- a/server/src/Middleware/checkOwnership.ts
+++ b/server/src/Middleware/checkOwnership.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { Database } from "sqlite";
 import jwt from "jsonwebtoken";
 import { ObjectHandler } from "../ObjectHandler";
+import { msgKey, translate } from "../Resources/i18n";
 
 const secret = process.env.JWT_SECRET || "your_jwt_secret";
 
@@ -16,7 +17,7 @@ export function checkOwnership(db: Database) {
   return async (req: Request, res: Response, next: NextFunction) => {
     const token = req.header("Authorization")?.replace("Bearer ", "");
     if (!token) {
-      res.status(401).json({ message: "Authentication required" });
+      res.status(401).json({ message: translate(req, msgKey.common.authenticationRequired) });
       return;
     }
 
@@ -27,7 +28,7 @@ export function checkOwnership(db: Database) {
       const userFromParamsId = await oh.getUserByMail(req.body.userEmail, db);
 
       if (!userFromTokenId || !userFromParamsId) {
-        res.status(404).json({ message: "User not found" });
+        res.status(404).json({ message: translate(req, msgKey.common.userNotFound) });
         return;
       }
 
@@ -35,11 +36,11 @@ export function checkOwnership(db: Database) {
         userFromTokenId?.getRole() !== "ADMIN" &&
         userFromParamsId?.getName() !== userFromTokenId?.getName()
       ) {
-        res.status(403).json({ message: "Forbidden: You can only edit your own data" });
+        res.status(403).json({ message: translate(req, msgKey.common.ownershipEditForbidden) });
         return;
       }
     } catch {
-      res.status(401).json({ message: "Invalid token" });
+      res.status(401).json({ message: translate(req, msgKey.common.invalidToken) });
       return;
     }
 

--- a/server/src/Resources/i18n.ts
+++ b/server/src/Resources/i18n.ts
@@ -1,0 +1,130 @@
+import { messages as enMessages } from "./messages.en";
+
+export type Locale = "en";
+
+const catalogs = {
+  en: enMessages,
+} as const;
+
+type Catalog = typeof catalogs.en;
+
+type LeafMessage = string | ((...args: any[]) => string);
+
+type DotPath<P extends string, K extends string> = P extends "" ? K : `${P}.${K}`;
+
+type Join<K extends string, P extends string> = P extends "" ? K : `${K}.${P}`;
+
+type LeafPaths<T> = T extends object
+  ? {
+      [K in keyof T & string]: T[K] extends LeafMessage
+        ? K
+        : T[K] extends object
+          ? Join<K, LeafPaths<T[K]>>
+          : never;
+    }[keyof T & string]
+  : never;
+
+export type MessageKey = LeafPaths<Catalog>;
+
+type PathValue<T, P extends string> = P extends `${infer K}.${infer Rest}`
+  ? K extends keyof T
+    ? PathValue<T[K], Rest>
+    : never
+  : P extends keyof T
+    ? T[P]
+    : never;
+
+type MessageArgs<K extends MessageKey> = PathValue<Catalog, K> extends (
+  ...args: infer A
+) => string
+  ? A
+  : [];
+
+type MessageKeyMirror<T, Prefix extends string = ""> = T extends object
+  ? {
+      [K in keyof T & string]: T[K] extends LeafMessage
+        ? DotPath<Prefix, K>
+        : T[K] extends object
+          ? MessageKeyMirror<T[K], DotPath<Prefix, K>>
+          : never;
+    }
+  : never;
+
+function createMessageKeyMirror<T extends object>(
+  obj: T,
+  prefix = ""
+): MessageKeyMirror<T> {
+  const out: any = Array.isArray(obj) ? [] : {};
+
+  for (const [rawKey, rawValue] of Object.entries(obj as Record<string, unknown>)) {
+    const nextPrefix = prefix ? `${prefix}.${rawKey}` : rawKey;
+
+    if (typeof rawValue === "string" || typeof rawValue === "function") {
+      out[rawKey] = nextPrefix;
+      continue;
+    }
+
+    if (rawValue && typeof rawValue === "object") {
+      out[rawKey] = createMessageKeyMirror(rawValue as object, nextPrefix);
+      continue;
+    }
+
+    out[rawKey] = nextPrefix;
+  }
+
+  return out as MessageKeyMirror<T>;
+}
+
+export const msgKey: MessageKeyMirror<Catalog> = createMessageKeyMirror(enMessages);
+
+function parseStartupLocale(value: unknown): Locale {
+  if (typeof value !== "string") return "en";
+  const lower = value.trim().toLowerCase();
+  if (lower === "en" || lower.startsWith("en-")) return "en";
+  return "en";
+}
+
+const startupLocale: Locale = parseStartupLocale(process.env.APP_LOCALE ?? process.env.LOCALE);
+const startupCatalog: Catalog = catalogs[startupLocale];
+
+function getValueByPath(obj: unknown, path: string): unknown {
+  const parts = path.split(".");
+  let current: any = obj;
+  for (const part of parts) {
+    if (current == null) return undefined;
+    current = current[part];
+  }
+  return current;
+}
+
+export function translate<K extends MessageKey>(
+  key: K,
+  ...args: MessageArgs<K>
+): string;
+export function translate<K extends MessageKey>(
+  req: unknown,
+  key: K,
+  ...args: MessageArgs<K>
+): string;
+export function translate<K extends MessageKey>(
+  reqOrKey: unknown,
+  keyOrArg?: K,
+  ...rest: any[]
+): string {
+  const hasReq = typeof reqOrKey !== "string";
+  const key = (hasReq ? keyOrArg : reqOrKey) as string;
+
+  const catalog = startupCatalog;
+  const value = getValueByPath(catalog, key) as LeafMessage | undefined;
+
+  if (typeof value === "function") {
+    return value(...rest);
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return key;
+}
+
+export const t = translate;

--- a/server/src/Resources/messages.en.ts
+++ b/server/src/Resources/messages.en.ts
@@ -1,0 +1,215 @@
+export const messages = {
+  common: {
+    internalServerError: "Internal server error",
+    requestProcessingError: "An error occurred while processing your request",
+    resourceNotFound: "Resource not found",
+    serverError: "Server error",
+
+    invalidEmailAddress: "Invalid email address",
+    userNotFound: "User not found",
+    projectNotFound: "Project not found",
+    courseNotFound: "Course not found",
+
+    pleaseFillInUrl: "Please fill in URL!",
+    invalidUrl: "Invalid URL",
+    urlAddedSuccessfully: "URL added successfully",
+    failedToAddUrl: "Failed to add URL",
+
+    notMemberOfProject: "You are not a member of this project",
+    leftProjectSuccessfully: "Left project successfully",
+    failedToLeaveProject: "Failed to leave project",
+
+    authenticationRequired: "Authentication required",
+    invalidToken: "Invalid token",
+    adminAccessRequired: "Forbidden: Admin access required",
+    ownershipEditForbidden: "Forbidden: You can only edit your own data",
+  },
+
+  term: {
+    termNameRequiredString: "Term name is required and must be a string",
+    termCreatedSuccessfully: "Term created successfully",
+    termIdRequired: "Term ID is required",
+    termIdMustBeValidNumber: "Term ID must be a valid number",
+    invalidTermIdFormat: "Invalid term ID format",
+    invalidTermId: "Invalid term ID",
+    termNotFound: "Term not found",
+    termDeletedSuccessfully: "Term deleted successfully",
+    courseAddedSuccessfully: "Course added successfully",
+  },
+
+  course: {
+    courseNameRequiredString: "Course name is required and must be a string",
+    courseIdRequired: "Course ID is required",
+    courseIdMustBeInteger: "Course ID must be an integer",
+    courseIdMustBeValidNumber: "Course ID must be a valid number",
+    invalidCourseIdFormat: "Invalid course ID format",
+    invalidCourseId: "Invalid course ID",
+    courseNotFound: "Course not found",
+    courseProjectsNotFound: "Course projects not found",
+
+    termIdRequired: "Term ID is required",
+    termIdMustBeValidNumber: "Term ID must be a valid number",
+
+    courseCreatedSuccessfully: "Course created successfully",
+    courseDeletedSuccessfully: "Course deleted successfully",
+
+    courseDeleteNotImplementedYet: "Course delete not implemented yet",
+    userCoursesNotImplementedYet: "User courses not implemented yet",
+
+    projectIdMustBeValidNumber: "Project ID must be a valid number",
+    projectNameRequiredString: "Project name is required and must be a string",
+    projectNotFound: "Project not found",
+    projectAddedSuccessfully: "Project added successfully",
+    projectUpdatedSuccessfully: "Project updated successfully",
+    projectDeletedSuccessfully: "Project deleted successfully",
+
+    startAndEndDateRequired: "Start date and end date are required",
+    scheduleSavedSuccessfully: "Schedule saved successfully",
+    scheduleNotFoundForCourse: "Schedule not found for this course",
+  },
+
+  user: {
+    failedToRetrieveUserStatus: "Failed to retrieve user status",
+    provideEmailAndStatus: "Please provide email and status",
+    userStatusUpdatedSuccessfully: "User status updated successfully",
+    failedToUpdateUserStatus: "Failed to update user status",
+
+    statusIsRequired: "Status is required",
+    noConfirmedUsersFoundToUpdate: "No confirmed users found to update",
+    allConfirmedUsersUpdatedTo: (status: string) => `All confirmed users have been updated to ${status}`,
+    failedToUpdateConfirmedUsers: "Failed to update confirmed users",
+
+    fillInNewEmail: "Please fill in new email!",
+    invalidEmailAddress: "Invalid email address",
+    emailUpdatedSuccessfully: "Email updated successfully",
+    failedToUpdateEmail: "Failed to update email",
+
+    fillInNewPassword: "Please fill in new password!",
+    passwordMinLength8: "Password must be at least 8 characters long",
+    passwordUpdatedSuccessfully: "Password updated successfully",
+    failedToUpdatePassword: "Failed to update password",
+
+    fillInUrl: "Please fill in URL!",
+    invalidUrl: "Invalid URL",
+    urlAddedSuccessfully: "URL added successfully",
+    failedToFetchUrl: "Failed to fetch URL",
+    failedToAddUrl: "Failed to add URL",
+    userEmailAndProjectNameMandatory: "User Email and Project Name are mandatory!",
+
+    userEmailRequiredBang: "User email is required!",
+    userEmailMandatoryBang: "User Email is mandatory!",
+
+    fillInGitHubUsername: "Please fill in GitHub username!",
+    githubUsernameAddedSuccessfully: "GitHub username added successfully",
+    failedToAddGitHubUsername: "Failed to add GitHub username",
+    failedToFetchGitHubUsername: "Failed to fetch GitHub username",
+
+    failedToRetrieveUserRole: "Failed to retrieve user role",
+    provideEmailAndRole: "Please provide email and role",
+    userRoleUpdatedSuccessfully: "User role updated successfully",
+    failedToUpdateUserRole: "Failed to update user role",
+
+    accountSuspendedSubject: "Account Suspended",
+    accountSuspendedBody:
+      "Your account has been suspended. Please contact the administrator for more information.",
+    accountRemovedSubject: "Account Removed",
+    accountRemovedBody:
+      "Your account has been removed. Please contact the administrator for more information.",
+  },
+
+  auth: {
+    fillInUsernameEmailPassword: "Please fill in username, email and password!",
+    passwordStrengthRequirements:
+      "Password must be at least 8 characters long and should contain upper and lower case letters as well as numbers or special characters",
+    emailWrongFormat: "email has not the right format",
+    nameMinLength3: "Name must be at least 3 characters long",
+
+    userRegisteredSuccessfully: "User registered successfully",
+
+    emailAndPasswordRequired: "Email and password are required",
+    invalidEmail: "Invalid email",
+    noPasswordSetForUser: "No password set for user",
+    invalidPassword: "Invalid password",
+
+    emailNotConfirmedContactAdmin: "Email not confirmed. Please contact system admin.",
+    userSuspendedContactAdmin: "User account is suspended. Please contact system admin.",
+    userRemovedContactAdmin: "User account is removed. Please contact system admin.",
+
+    loginFailed: "Login failed",
+
+    userEmailIsRequired: "User email is required",
+    emailNotFound: "Email not found",
+    passwordResetEmailSent: "Password reset email sent",
+
+    tokenAndNewPasswordRequired: "Token and new password are required",
+    invalidOrExpiredResetToken: "Invalid or expired reset token",
+    invalidOrExpiredToken: "Invalid or expired token",
+    passwordHasBeenReset: "Password has been reset",
+
+    tokenIsRequired: "Token is required",
+    invalidOrExpiredConfirmationToken: "Invalid or expired confirmation token",
+    emailHasBeenConfirmed: "Email has been confirmed",
+
+    userNotFoundOrNotUnconfirmed: "User not found or not unconfirmed",
+    confirmationEmailSent: "Confirmation email sent",
+    failedToSendConfirmationEmail: "Failed to send confirmation email",
+
+    confirmEmailSubject: "Confirm Email",
+    confirmEmailBody: (confirmedLink: string) =>
+      `You registered for Happy Go Lucky! Click the link to confirm your email: ${confirmedLink}`,
+
+    passwordResetSubject: "Password Reset",
+    passwordResetBody: (resetLink: string) =>
+      `You requested a password reset. Click the link to reset your password: ${resetLink}`,
+  },
+
+  project: {
+    courseIdIsRequired: "Course id is required",
+    failedToRetrieveProjectsForCourse: (courseName: unknown) =>
+      `Failed to retrieve projects for course ${courseName}`,
+
+    fillInProjectGroupAndProjectName: "Please fill in project group name and project name",
+    projectEditedSuccessfully: "Project edited successfully",
+    projectEditionFailed: "Project edition failed",
+
+    projectNameIsRequired: "Project name is required",
+    courseNotFoundForProject: "Course not found for this project",
+    failedToFetchCourse: "Failed to fetch course",
+
+    userEmailIsRequired: "User email is required",
+    projectNameAndUserEmailRequired: "Project name and user email are required",
+    roleNotFound: "Role not found",
+    failedToRetrieveProjectRole: "Failed to retrieve project role",
+
+    fillInYourRole: "Please fill in your role",
+    alreadyJoinedProject: "You have already joined this project",
+    joinedProjectSuccessfully: "Joined project successfully",
+    failedToJoinProject: "Failed to join project",
+
+    leftProjectSuccessfully: "Left project successfully",
+    failedToLeaveProject: "Failed to leave project",
+    notMemberOfProject: "You are not a member of this project",
+
+    failedToRetrieveUserProjects: "Failed to retrieve user projects",
+    failedToRetrieveCoursesOfUser: "Failed to retrieve courses of user",
+
+    submissionDateIdRequiredNumber: "Submission date ID is required and must be a number",
+    submissionDateNotFound: "Submission date not found",
+    projectOrUserNotFound: "Project or user not found",
+    happinessUpdatedSuccessfully: "Happiness updated successfully",
+    failedToUpdateHappiness: "Failed to update happiness",
+    failedToFetchHappinessData: "Failed to fetch happiness data",
+
+    noScheduleFoundForCourse: "No schedule found for this course",
+    noFutureSubmissionDatesAvailable: "No future submission dates available",
+    failedToFetchAvailableSubmissions: "Failed to fetch available submissions",
+
+    noMembersInProjectGroup: "No members in the project group",
+    standupEmailSentSuccessfully: "Standup email sent successfully",
+    failedToSendStandupEmail: "Failed to send standup email",
+
+    standupEmailSubject: (projectName: string) => `Standup Update for ${projectName}`,
+    standupEmailBody: (userName: string, doneText: string, plansText: string, challengesText: string) =>
+      `Standup report from ${userName}\n\nDone: ${doneText}\nPlans: ${plansText}\nChallenges: ${challengesText}`,
+  },
+} as const;


### PR DESCRIPTION
- Centralize user-facing responses in [server/src/Resources/messages.en.ts](server/src/Resources/messages.en.ts)
- Use `translate()` + `msgKey` across controllers and auth middleware
- Select locale at startup via `APP_LOCALE`/`LOCALE` (no runtime switching)

<!-- Please remove the line that does not fit. -->
<!-- Please also enter the respective issue ID after the #. -->
<!-- E.g.: This issue closes #1. -->
This issue closes #3.
This issue is part of #35.

<!-- Please include a summary of the changes and the related issue. -->
<!-- Please also include relevant motivation and context. -->

This PR moves hardcoded English response strings out of the server implementation and into a dedicated English resource file, as requested in #3.

It introduces a lightweight localization helper ([server/src/Resources/i18n.ts](server/src/Resources/i18n.ts)) that:
- provides `translate()` for fetching messages (with typed keys), and
- exposes `msgKey.*` for IDE autocomplete/typo prevention.

To keep localization simple (no new libraries) and match the issue requirement, the active locale is chosen once at system startup using `APP_LOCALE` or `LOCALE` (no request-based runtime switching).

## How can this be tested?

From the repo root:

1. `npm ci --prefix server`
2. `npm run build --prefix server`
3. `npm test --prefix server`
4. `npm run lint --prefix server`

(Optional) Start the server with a locale:
- `APP_LOCALE=en npm run dev --prefix server`

## Screenshots

No UI changes.

## Checklist

- [x ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have lowered the linter errors. Before: <NUMBER>. After: <NUMBER>
