### PR TITLE
Fix: initialize schema in db for mockdata scripts on first run (#89)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ dist
 # User files
 /server/database.sqlite
 /server/myDatabase.db
+/myDatabase.db
 
 # AI agents
 CLAUDE.md

--- a/server/src/scripts/generateMockData.ts
+++ b/server/src/scripts/generateMockData.ts
@@ -1,6 +1,8 @@
-import sqlite3 from 'sqlite3';
-import { open } from 'sqlite';
+import dotenv from 'dotenv';
 import { hashPassword } from '../Utils/hash';
+import { initializeDB } from '../databaseInitializer';
+
+dotenv.config();
 
 /**
  * Generates mock data for development.
@@ -8,13 +10,13 @@ import { hashPassword } from '../Utils/hash';
  * Creates a semester with students, courses, projects,
  * and happiness ratings for past sprints.
  */
-async function generateMockData(dbPath: string = './server/myDatabase.db', deleteOnly: boolean = false) {
+async function generateMockData(
+  dbPath: string = process.env.DB_PATH || './myDatabase.db',
+  deleteOnly: boolean = false
+) {
   console.log(`Connecting to database at: ${dbPath}`);
 
-  const db = await open({
-    filename: dbPath,
-    driver: sqlite3.Database,
-  });
+  const db = await initializeDB(dbPath, !deleteOnly);
 
   try {
     console.log('Starting mock data generation...\n');
@@ -239,7 +241,7 @@ async function generateMockData(dbPath: string = './server/myDatabase.db', delet
 
 const args = process.argv.slice(2);
 const deleteOnly = args.includes('--delete-only');
-const dbPath = args.find(arg => !arg.startsWith('--')) || './server/myDatabase.db';
+const dbPath = args.find(arg => !arg.startsWith('--')) || process.env.DB_PATH || './myDatabase.db';
 
 generateMockData(dbPath, deleteOnly)
   .then(() => {


### PR DESCRIPTION
This PR closes #89.
<!-- This issue is part of #<issue-id>. -->

## Summary

Running `generate-mockdata` right after the first `npm run build` (without `npm run dev` in between) could fail on a fresh project because the SQLite schema was not initialized yet (e.g. `SQLITE_ERROR: no such table: happiness`).

This PR ensures the database schema is always initialized before the mockdata script performs any deletes/inserts, regardless of how the system is started or which script is run first.

## Changes

- Initialize the DB schema at the start of the mockdata script by reusing the shared `initializeDB(...)` logic.
- Load environment variables in the script so `DB_PATH` is respected.
- Align the script default DB path with the server default (`DB_PATH` or `./myDatabase.db`).
- Ignore the default root DB file (`./myDatabase.db`) to prevent untracked artifacts after running scripts locally.

## How can this be tested?

1. Checkout this branch.
2. Ensure there is no local DB file:
   - `rm -f myDatabase.db server/myDatabase.db`
3. Run build + mockdata without starting dev:
   - `npm run build --prefix server`
   - `npm run generate-mockdata`


Optional: run server tests
- `npm test --prefix server`

## Screenshots

No UI changes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have lowered the linter errors. Before: <NUMBER>. After: <NUMBER>