### PR TITLE
Add backend API documentation (reference + development guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Run automated tests:
 npm run test
 ```
 
+## API Documentation
+
+- API reference: [docs/API.md](docs/API.md)
+- API development guide: [docs/API_DEVELOPMENT.md](docs/API_DEVELOPMENT.md)
+
 
 ## Deployment
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,372 @@
+# Happy Go Lucky API Reference
+
+This document describes the **existing** backend HTTP API exposed by the HGL Express server.
+
+## Base URL
+
+The backend registers routes at the root (e.g. `/user`, `/term`). How you reach it depends on your setup:
+
+- **Local dev (direct backend):** `http://localhost:3000` → call `http://localhost:3000/user`, `http://localhost:3000/session`, …
+- **Production via Caddy:** the frontend calls `/api/*`, Caddy strips `/api` and forwards to the backend.
+  - Example: `https://your-domain.com/api/session` → backend receives `POST /session`.
+
+## Request/Response conventions
+
+- Requests with bodies use `Content-Type: application/json`.
+- Most endpoints return JSON.
+- Response envelopes are **not fully consistent** across all endpoints:
+  - Newer endpoints often use `{ "success": boolean, "message"?: string, "data"?: any }`.
+  - Several endpoints return a **raw array/object** directly (e.g. `GET /getUsers`, `GET /courseProject`).
+
+## Authentication
+
+Authentication is based on **JWT**.
+
+1. Obtain a token via `POST /session`.
+2. Send it on protected endpoints:
+
+```http
+Authorization: Bearer <jwt>
+```
+
+The JWT secret is read from `JWT_SECRET` (falls back to `"your_jwt_secret"` if unset).
+
+### Authorization rules
+
+Some routes require:
+
+- **Admin**: must have `userRole === "ADMIN"` (checked by middleware).
+- **Ownership or Admin**: must be the same user as the `userEmail` in the request body *or* be an admin.
+
+## Common status codes
+
+- `200` OK
+- `201` Created (some write endpoints)
+- `400` Validation error / bad request
+- `401` Authentication required / invalid token
+- `403` Forbidden (insufficient permissions)
+- `404` Not found
+- `500` Server error
+
+## Quick examples
+
+### Login
+
+```bash
+curl -sS -X POST http://localhost:3000/session \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@test.com","password":"Test123!"}'
+```
+
+### Admin-only: create term
+
+```bash
+TOKEN="…"
+curl -sS -X POST http://localhost:3000/term \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"termName":"SS2026","displayName":"Summer 2026"}'
+```
+
+---
+
+# Endpoints
+
+## Health
+
+### `GET /`
+
+Returns a plain string.
+
+- **Response:** `200` with body `Server is running!`
+
+## Authentication
+
+### `POST /user` — Register
+
+- **Body**
+  - `name` (string, min length 3)
+  - `email` (string, valid email)
+  - `password` (string; must meet strength requirements)
+- **Response**
+  - `201 { "message": "User registered successfully" }`
+  - `400 { "message": "…" }` on validation errors
+
+Notes:
+- Newly registered users start with status `unconfirmed`.
+- The server generates a confirmation token and sends a confirmation email (email delivery depends on environment).
+
+### `POST /session` — Login
+
+- **Body**
+  - `email` (string)
+  - `password` (string)
+- **Response**
+  - `200 { token, name, email, githubUsername }`
+  - `400 { message }` for invalid credentials, invalid email format, or blocked user state
+
+User states that block login:
+- `unconfirmed` → “Email not confirmed…”
+- `suspended` → “User account is suspended…”
+- `removed` → “User account is removed…”
+
+### `POST /user/password/forgotMail` — Request password reset
+
+- **Body**: `{ "email": string }`
+- **Response**
+  - `200 { "message": "Password reset email sent" }`
+  - `404 { "message": "Email not found" }`
+
+### `POST /user/password/reset` — Reset password
+
+- **Body**: `{ "token": string, "newPassword": string }`
+- **Response**
+  - `200 { "message": "Password has been reset" }`
+  - `401 { "message": "Invalid or expired reset token" }`
+
+### `POST /user/confirmation/email` — Confirm email
+
+- **Body**: `{ "token": string }`
+- **Response**
+  - `200 { "message": "Email has been confirmed" }`
+  - `401 { "message": "Invalid or expired confirmation token" }`
+
+### `POST /user/confirmation/trigger` — Resend confirmation email
+
+- **Body**: `{ "email": string }`
+- **Response**
+  - `200 { "message": "Confirmation email sent" }`
+  - `400 { "message": "User not found or not unconfirmed" }` (already confirmed / not eligible)
+
+## Terms
+
+### `GET /term` — List terms
+
+- **Auth:** none
+- **Response:**
+  - `200 { success: true, data: Array<{ id, termName, displayName }> }`
+
+### `POST /term` — Create term
+
+- **Auth:** admin (`Authorization: Bearer …`)
+- **Body**: `{ termName: string, displayName?: string }`
+- **Response:**
+  - `201 { success: true, message: "Term created successfully", data: … }`
+
+### `DELETE /term/:id` — Delete term
+
+- **Auth:** admin
+- **Response:**
+  - `200 { success: true, message: "Term deleted successfully" }`
+  - `400` if the term still has courses (cannot delete)
+
+### `POST /termCourse` — Add course to term
+
+- **Auth:** admin
+- **Body**: `{ termId: number, courseName: string }`
+- **Response:**
+  - `201 { success: true, message: "Course added successfully", data: { id, courseName, termId } }`
+
+### `GET /term/courses` — List courses for a term
+
+- **Auth:** none
+- **Query**: `termId=<number>`
+- **Response:**
+  - `200 { success: true, data: Array<{ id, courseName, termId }> }`
+
+## Courses
+
+### `POST /course` — Create course
+
+- **Auth:** none
+- **Body**: `{ courseName: string, termId: number }`
+- **Response:**
+  - `201 { success: true, message: "Course created successfully", data: … }`
+
+### `GET /course` — List courses
+
+- **Auth:** none
+- **Response:**
+  - `200 { success: true, data: Array<{ id, courseName, termId }> }`
+
+### `DELETE /course/:id` — Delete course
+
+- **Auth:** admin
+- **Response:**
+  - `200 { success: true, message: "Course deleted successfully" }`
+  - `400` if the course still has projects
+
+### `POST /courseProject` — Create a project within a course
+
+- **Auth:** none
+- **Body**: `{ courseId: number, projectName: string }`
+- **Response:**
+  - `201 { success: true, message: "Project added successfully", data: { id, projectName, courseId } }`
+
+### `GET /course/courseProjects` — List course projects
+
+- **Auth:** none
+- **Query**:
+  - `courseId=<number>`
+  - Optional `userEmail=<email>` to split into `enrolledProjects` and `availableProjects`
+- **Response**:
+  - Default: `200 { success: true, data: Array<{ id, projectName, courseId }> }`
+  - With `userEmail`: `200 { success: true, enrolledProjects: […], availableProjects: […] }`
+
+### `PUT /courseProject/:id` — Update a course project
+
+- **Auth:** none
+- **Body**: `{ projectName: string, courseId?: number }`
+- **Response:**
+  - `200 { success: true, message: "Project updated successfully", data: { id, projectName, courseId } }`
+
+### `DELETE /courseProject/:id` — Delete a course project
+
+- **Auth:** none
+- **Response:**
+  - `200 { success: true, message: "Project deleted successfully" }`
+
+### `POST /course/:id/schedule` — Create/update course schedule
+
+- **Auth:** none
+- **Body**:
+  - `startDate` (string, e.g. `"2024-01-01"`)
+  - `endDate` (string)
+  - `submissionDates?` (string[], optional)
+- **Response:**
+  - `200 { success: true, message: "Schedule saved successfully", data: { id, startDate, endDate, submissionDates } }`
+
+### `GET /course/:id/schedule` — Get course schedule
+
+- **Auth:** none
+- **Response:**
+  - `200 { success: true, data: { id, startDate, endDate, submissionDates } }`
+
+## Project management & membership
+
+These endpoints are implemented in `ProjectController` and are mostly **not** wrapped in `{success, data}`.
+
+### `GET /courseProject` — List projects by course name
+
+- **Query**: `courseName=<string>`
+- **Response:** `200` raw array of rows like `{ id, projectName, courseId }`
+
+### `PUT /courseProject` — Edit project (legacy-ish, name-based)
+
+- **Body**: `{ projectName, newProjectName, newCourseName }`
+- **Response:** `201 { "message": "Project edited successfully" }`
+
+### `GET /courseProject/course` — Get course for a project
+
+- **Query**: `projectName=<string>`
+- **Response:** `200 { courseId, courseName }`
+
+### `GET /courseProject/user/role` — Get role of a user in a project
+
+- **Query**: `projectName=<string>&email=<email>`
+- **Response:** `200 { "role": string }`
+
+### `POST /user/project` — Join project
+
+- **Body**: `{ projectName, memberEmail, memberRole }`
+- **Response:** `201 { "message": "Joined project successfully" }`
+
+### `DELETE /user/project` — Leave project
+
+- **Body**: `{ projectName, userEmail }`
+- **Response:** `200 { "message": "Left project successfully" }`
+
+### `GET /user/projects` — List projects of a user
+
+- **Query**: `userEmail=<email>`
+- **Response:** `200` raw array of `{ id, projectName }`
+
+### `GET /user/courses` — List enrolled courses of a user
+
+- **Query**: `userEmail=<email>`
+- **Response:** `200` raw array of `{ id, courseName }`
+
+## Happiness & standups
+
+### `POST /courseProject/happiness` — Save happiness metric
+
+- **Body**: `{ projectName, userEmail, happiness: number, submissionDateId: number }`
+- **Response:** `200 { "message": "Happiness updated successfully" }`
+
+### `GET /courseProject/happiness` — Get happiness metrics
+
+- **Query**: `projectName=<string>`
+- **Response:** `200` raw array of entries containing `submissionDate`, `userEmail`, `happiness`, `timestamp`, …
+
+### `GET /courseProject/availableSubmissions` — Next available submission date
+
+- **Query**: `projectName=<string>`
+- **Response:** `200 { id, submissionDate: ISOString, scheduleId }`
+
+### `POST /courseProject/standupsEmail` — Send standup email to project members
+
+- **Body**: `{ projectName, userName, doneText, plansText, challengesText }`
+- **Response:** `200 { "message": "Standup email sent successfully" }`
+
+## Users (administration & configuration)
+
+### `GET /getUsers` — List all users
+
+- **Auth:** none
+- **Response:** `200` raw array of user rows
+
+### `GET /user/status` — Filter users by status
+
+- **Query**: `status=<confirmed|unconfirmed|suspended|removed>`
+- **Response:** `200` raw array
+
+### `POST /user/status` — Update a user’s status
+
+- **Auth:** ownership or admin (JWT)
+- **Body**: `{ userEmail: string, status: string }`
+- **Response:** `200 { "message": "User status updated successfully" }`
+
+### `POST /user/status/all` — Bulk-update all confirmed users
+
+- **Auth:** none
+- **Body**: `{ status: string }`
+- **Response:** `200 { "message": "All confirmed users have been updated to …" }`
+
+### `POST /user/mail` — Change email
+
+- **Body**: `{ oldEmail: string, newEmail: string }`
+- **Response:** `200 { "message": "Email updated successfully" }`
+
+### `POST /user/password/change` — Change password
+
+- **Body**: `{ userEmail: string, password: string }`
+- **Response:** `200 { "message": "Password updated successfully" }`
+
+### `POST /user/githubUsername` / `GET /user/githubUsername`
+
+- **POST Body**: `{ userEmail: string, newGithubUsername: string }`
+- **GET Query**: `userEmail=<email>`
+- **Response:** `200 { githubUsername: string }` (empty string when unset)
+
+### `POST /user/project/url` / `GET /user/project/url`
+
+- **POST Body**: `{ userEmail, projectName, URL }` (must contain `"git"`)
+- **GET Query**: `userEmail=<email>&projectName=<string>`
+- **Response:** `200 { url: string | null }`
+
+### `GET /user/role` / `POST /user/role`
+
+- **GET Query**: `userEmail=<email>` → returns `{ userRole: "ADMIN" | "USER" }`
+- **POST Body**: `{ email: string, role: string }` → sets `users.userRole`
+
+## Legacy endpoints
+
+These exist for backward compatibility.
+
+### `POST /projConfig/changeURL`
+
+Same as `POST /user/project/url`.
+
+### `POST /projConfig/leaveProject`
+
+Same as `DELETE /user/project` (but uses `POST`).

--- a/docs/API_DEVELOPMENT.md
+++ b/docs/API_DEVELOPMENT.md
@@ -1,0 +1,206 @@
+# API Development Guide (Backend)
+
+This guide explains how to extend the existing HGL backend API safely and consistently.
+
+> Scope: backend code in `server/src/*` (Express + SQLite).
+
+## Architecture at a glance
+
+- The Express app is created in `server/src/createApp.ts`.
+  - JSON parsing via `body-parser`.
+  - CORS enabled for `CLIENT_URL` (defaults to `http://localhost:5173`).
+- Each controller implements `IAppController` and registers routes in `init(app)`.
+  - Controllers live in `server/src/Controllers/*Controller.ts`.
+- Business/data logic lives in two main styles:
+  - **Managers** (e.g. `CourseManager`, `TermManager`) + domain models.
+  - **Direct SQL** in a controller (notably `ProjectController`).
+
+## Route registration
+
+Routes are registered in `createApp`:
+
+- Instantiate controllers
+- Call `.init(app)`
+
+If you add a new controller, remember to:
+
+1. Create the controller in `server/src/Controllers/…` and implement `IAppController`.
+2. Instantiate it in `server/src/createApp.ts`.
+3. Call `yourController.init(app)`.
+
+## Authentication & authorization
+
+### JWT
+
+- Login endpoint (`POST /session`) returns a JWT.
+- Protected endpoints expect:
+
+```http
+Authorization: Bearer <jwt>
+```
+
+The JWT secret is `JWT_SECRET`.
+
+### Middlewares
+
+Use the existing middleware where applicable:
+
+- `checkAdmin(db)`
+  - Requires a valid JWT.
+  - Loads the user from DB using the `id` in the token.
+  - Allows only `userRole === "ADMIN"`.
+- `checkOwnership(db)`
+  - Requires a valid JWT.
+  - Compares the token’s user with `req.body.userEmail`.
+  - Admins can edit anyone; regular users can only edit themselves.
+
+When adding a protected endpoint:
+
+- Prefer middleware at the route level:
+  - `app.post('/term', checkAdmin(db), this.createTerm.bind(this))`
+- Keep middleware responses consistent (`401` for missing/invalid token, `403` for forbidden).
+
+## Input validation
+
+The codebase uses explicit validation inside controller methods.
+
+Recommended pattern:
+
+1. Validate presence and type (`typeof x === 'string'`).
+2. Parse numbers with `parseInt` and check `isNaN`.
+3. For emails, prefer the `Email` value type (`server/src/ValueTypes/Email.ts`) when used in new code.
+4. Return early with `400` if validation fails.
+
+### Keep names stable
+
+Frontend/tests currently depend on existing field names like:
+
+- `courseName`, `termId`
+- `projectName`
+- `userEmail`, `memberEmail`, `newGithubUsername`
+
+If you introduce new endpoints, prefer consistent camelCase names.
+
+## Error handling & response shapes
+
+There is some inconsistency today:
+
+- Term/Course endpoints often return `{ success, message, data }`.
+- Some project/user endpoints return `{ message }` or raw arrays.
+
+For **new** endpoints, prefer the newer envelope:
+
+```json
+{ "success": true, "message": "…", "data": { } }
+```
+
+And for errors:
+
+```json
+{ "success": false, "message": "…" }
+```
+
+Status code guidance:
+
+- `400` validation/format errors
+- `401` missing/invalid JWT
+- `403` authenticated but not allowed
+- `404` resource not found
+- `500` unexpected errors
+
+If you’re adding endpoints to `CourseController`/`TermController`, reuse the controller’s `handleError` pattern.
+
+## Working with the database
+
+- The backend uses SQLite via the `sqlite` package.
+- Helpers like `DatabaseHelpers` exist for common lookups.
+
+Recommended approach:
+
+- If the feature belongs to courses/terms/projects as domain objects, prefer going through a **Manager**.
+- If you must use raw SQL:
+  - Keep queries small and readable.
+  - Use parameterized queries (`?`) to avoid injection.
+  - Decide on a stable response format and test it.
+
+## Adding a new endpoint: checklist
+
+1. **Choose a controller**
+   - Add related endpoints to an existing controller when it matches the domain.
+   - Otherwise create a new controller and register it in `createApp`.
+2. **Add the route in `init(app)`**
+3. **Implement the handler**
+   - Validate inputs
+   - Perform DB/manager operations
+   - Return consistent JSON + status code
+4. **Add/adjust auth middleware** (if needed)
+5. **Write tests** (required)
+6. **Run formatting/lint/tests**
+
+## Testing the API
+
+Backend API tests live in:
+
+- `server/src/tests/api/*.api.test.ts`
+
+They use:
+
+- **Vitest** (`vitest run`)
+- **Supertest** for HTTP calls against an in-memory Express app
+- Helpers in `server/src/tests/api/helpers/*` to create/seed a test DB
+
+### Running tests
+
+From repo root:
+
+```bash
+npm run test
+```
+
+Or backend-only:
+
+```bash
+npm test --prefix server
+```
+
+### Adding a test
+
+- Create/extend a file in `server/src/tests/api/`.
+- Use `createTestDb()` + `seedDatabase(db)`.
+- Create the Express app with `createApp(db)`.
+
+If your endpoint requires JWT:
+
+- Use helpers like `generateAdminToken()` / `generateUserToken()` and `createAuthHeader()` (see `server/src/tests/api/helpers/authHelpers.ts`).
+
+## Local development
+
+From repo root:
+
+```bash
+npm run dev
+```
+
+This runs client + server concurrently.
+
+Backend runs on `PORT` (default `3000`).
+
+## Email behavior in development
+
+Email sending is configured in `server/src/createApp.ts`:
+
+- Production: SMTP or local MTA, depending on env vars.
+- Development: `ConsoleEmailService` (prints emails to stdout).
+
+When adding endpoints that send email, prefer using the injected `IEmailService` like existing controllers do.
+
+## Deployment note: `/api` prefix
+
+In production, Caddy proxies `/api/*` to the backend and strips the `/api` prefix.
+
+That means:
+
+- Frontend calls: `https://your-domain.com/api/session`
+- Backend route remains: `POST /session`
+
+If you add new backend routes, the frontend should call them with `/api/<route>` when deployed behind Caddy.


### PR DESCRIPTION

This PR is a part of #95 .

<!-- This issue is part of #<issue-id>. -->

Added comprehensive backend API documentation based on the current Express controllers and the existing `server/src/tests/api/*.api.test.ts` suite.

Summary of changes:
- Added an API reference documenting base URL behavior (including Caddy `/api` proxying), authentication/authorization, status codes, and all currently exposed endpoints (auth, terms, courses, projects/membership, happiness, standups, user admin/config, and legacy routes).
- Added an API development guide describing the backend architecture (controllers/managers), how to register new routes, recommended validation + response conventions, auth middleware usage, and how to add API tests.

Motivation/context:
- Make it easier for contributors to understand what endpoints exist today and to extend the API consistently without breaking the client or tests.

## How can this be tested?

1. Run backend tests:
   - `npm test --prefix server`
2. (Optional) Run all tests:
   - `npm run test`
3. Sanity-check docs render and links:
   - Open `docs/API.md` and `docs/API_DEVELOPMENT.md`
   - Verify README links resolve correctly

## Screenshots

No UI changes were made.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have lowered the linter errors. Before: <NUMBER>. After: <NUMBER>