### PR TITLE
feat(auth): add "Remember me" login option (#96)

### DIFF
--- a/client/src/screens/Auth/LoginScreen.tsx
+++ b/client/src/screens/Auth/LoginScreen.tsx
@@ -15,6 +15,7 @@ const LoginScreen = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");
+  const [rememberMe, setRememberMe] = useState(false);
   const [message, setMessage] = useState("");
 
   // Updates email based on the value from EmailWidget
@@ -42,7 +43,7 @@ const LoginScreen = () => {
         const data = await authApi.register(email, password, name);
         setMessage(data.message || "Registration successful! Please check your email to confirm your account.");
       } else {
-        const data = await authApi.login(email, password);
+        const data = await authApi.login(email, password, rememberMe);
         console.log("Response data:", data);
 
         authStorage.setToken(data.token);
@@ -165,13 +166,27 @@ const LoginScreen = () => {
                   />
                 </Form.Field>
 
-                <div className="text-sm text-slate-600">
-                  Forget Password?{" "}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center">
+                    <input
+                      id="rememberMe"
+                      type="checkbox"
+                      checked={rememberMe}
+                      onChange={(e) => setRememberMe(e.target.checked)}
+                      className="size-4 rounded border-gray-300 bg-gray-100 text-blue-600"
+                    />
+                    <label
+                      htmlFor="rememberMe"
+                      className="ms-2 cursor-pointer text-sm font-medium text-gray-900"
+                    >
+                      Remember me
+                    </label>
+                  </div>
                   <a
                     href="/ForgotPassword"
-                    className="font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                    className="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
                   >
-                    Click here
+                    Forgot Password?
                   </a>
                 </div>
 

--- a/client/src/services/api/auth.ts
+++ b/client/src/services/api/auth.ts
@@ -5,10 +5,11 @@ import { LoginResponse, RegisterResponse } from "@/types/api";
  * Authentication API methods
  */
 const authApi = {
-  login: async (email: string, password: string): Promise<LoginResponse> => {
+  login: async (email: string, password: string, rememberMe: boolean = false): Promise<LoginResponse> => {
     return ApiClient.getInstance().post<LoginResponse>("/session", {
       email,
       password,
+      rememberMe,
     });
   },
 

--- a/server/src/Controllers/AuthController.ts
+++ b/server/src/Controllers/AuthController.ts
@@ -115,10 +115,15 @@ export class AuthController implements IAppController {
   }
 
   async login(req: Request, res: Response): Promise<void> {
-    const { email, password } = req.body;
+    const { email, password, rememberMe } = req.body;
     const passwordObj = Password.create(password);
     if (!email || !passwordObj || typeof email !== "string") {
       res.status(400).json({ message: "Email and password are required" });
+      return;
+    }
+
+    if (rememberMe !== undefined && typeof rememberMe !== "boolean") {
+      res.status(400).json({ message: "rememberMe must be a boolean" });
       return;
     }
 
@@ -171,8 +176,9 @@ export class AuthController implements IAppController {
         return;
       }
 
+      // Token expiry: 30 days if rememberMe, otherwise 1 hour
       const token = jwt.sign({ id: user.getId() }, process.env.JWT_SECRET || "your_jwt_secret", {
-        expiresIn: "1h",
+        expiresIn: rememberMe === true ? "30d" : "1h",
       });
       res.status(200).json({
         token,


### PR DESCRIPTION
Addresses #96 

Added a "Remember me" checkbox to the login screen. When checked, the JWT token 
expires after 30 days instead of 1 hour.

Also fixed a typo: "Forget Password?" -> "Forgot Password?"

## Testing

**Added 4 tests** for the `rememberMe` parameter:
- `rememberMe: true` -> token expires in 30 days
- `rememberMe: false` -> token expires in 1 hour
- No `rememberMe` (default) -> token expires in 1 hour
- Non-boolean `rememberMe` -> returns 400 Bad Request

**Manual testing:**
1. `npm run dev` -> http://localhost:5173
2. Login without checkbox -> get token from DevTools: Application -> Local Storage
3. Decode token -> `exp - iat` should be `3600` (1 hour)
4. Login with checkbox -> decode token -> `exp - iat` should be `2592000` (30 days)

**Or run tests:** `npm test` (275 tests pass)

## Screenshots

### Before:
<img width="344" height="356" alt="Screenshot 2026-02-04 043838" src="https://github.com/user-attachments/assets/99b0348d-1a3b-4914-984d-51f1260323d4" />


### After:
<img width="344" height="356" alt="Screenshot 2026-02-04 043853" src="https://github.com/user-attachments/assets/2499ed32-3bbd-439b-b15a-1b2252622264" />
<img width="344" height="356" alt="Screenshot 2026-02-04 043857" src="https://github.com/user-attachments/assets/5c319e3a-efa8-45ab-91f0-a5df6c5237f5" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have lowered the linter errors. Before: 0. After: 0

---
Ready for review @georg-schwarz
