### PR TITLE
refactor(email): standardize SMTP env vars and provider config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,8 +44,19 @@ JWT_SECRET=your_secure_random_jwt_secret_here
 # =============================================================================
 
 # Required: Email credentials for sending emails in production
-EMAIL_USER_FAU=your.email@fau.de
-EMAIL_PASS_FAU=your_fau_email_password
+# For FAU: use your FAU email and password
+# For Gmail: use your Gmail address and an app password (not your regular password)
+EMAIL_SMTP_USER=your.email@fau.de
+EMAIL_SMTP_PASS=your_email_password_or_app_password
+
+# Optional: Override default email sender (name and address)
+# EMAIL_FROM_NAME="Happy Go Lucky"
+# EMAIL_FROM_ADDRESS=dirk.riehle@fau.de
+
+# Optional: Override default SMTP settings
+# EMAIL_SMTP_HOST=smtp-auth.fau.de
+# EMAIL_SMTP_PORT=465
+# EMAIL_SMTP_SECURE=true
 
 # =============================================================================
 # Optional Features

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -105,9 +105,10 @@ dig your-domain.com
    # Run: openssl rand -base64 32
    JWT_SECRET=your_secure_random_jwt_secret_here
 
-   # Your FAU email credentials for sending emails
-   EMAIL_USER_FAU=your.email@fau.de
-   EMAIL_PASS_FAU=your_secure_password
+   # SMTP credentials for sending emails
+   # For Gmail, use an app password (not your regular account password)
+   EMAIL_SMTP_USER=your.email@fau.de
+   EMAIL_SMTP_PASS=your_secure_password
 
    # Optional: GitHub token for code activity features
    VITE_GITHUB_TOKEN=your_github_personal_access_token
@@ -250,12 +251,28 @@ For local testing without a domain or HTTPS:
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `EMAIL_USER_FAU` | Production | - | FAU email username for sending emails |
-| `EMAIL_PASS_FAU` | Production | - | FAU email password |
+| `EMAIL_SMTP_USER` | Production | - | SMTP username for sending emails (FAU email or Gmail address) |
+| `EMAIL_SMTP_PASS` | Production | - | SMTP password or app password for sending emails |
+| `EMAIL_FROM_NAME` | No | `Happy Go Lucky` | Sender name displayed in emails |
+| `EMAIL_FROM_ADDRESS` | No | `dirk.riehle@fau.de` | Sender email address |
+| `EMAIL_SMTP_HOST` | No | `smtp-auth.fau.de` | SMTP server hostname |
+| `EMAIL_SMTP_PORT` | No | `465` | SMTP server port |
+| `EMAIL_SMTP_SECURE` | No | `true` | Whether to use TLS/SSL for SMTP connection (true/false) |
 
 **Email Behavior:**
 - **Development** (`NODE_ENV !== 'production'`): Emails logged to console, not sent
-- **Production** (`NODE_ENV === 'production'`): Emails sent via FAU SMTP server
+- **Production** (`NODE_ENV === 'production'`): 
+  - If `EMAIL_SMTP_USER` and `EMAIL_SMTP_PASS` are set: Emails sent via configured SMTP server
+  - Otherwise: Falls back to local MTA (if available)
+
+**Supported Email Providers:**
+- **FAU**: Uses default settings (`smtp-auth.fau.de:465`)
+- **Gmail**: 
+  - `EMAIL_SMTP_HOST=smtp.gmail.com`
+  - `EMAIL_SMTP_PORT=465` (or 587 with `EMAIL_SMTP_SECURE=false`)
+  - `EMAIL_SMTP_USER=your@gmail.com`
+  - `EMAIL_SMTP_PASS=<your 16-character Gmail app password>`
+  - Requires 2-Factor Authentication enabled on Google account
 
 ### Optional Features
 
@@ -659,7 +676,7 @@ docker compose restart server
 
 **Check configuration:**
 1. Verify `NODE_ENV=production` in docker-compose.yml
-2. Verify `EMAIL_USER_FAU` and `EMAIL_PASS_FAU` are correct in `.env`
+2. Verify `EMAIL_SMTP_USER` and `EMAIL_SMTP_PASS` are correct in `.env`
 3. Check server logs for SMTP errors:
    ```bash
    docker compose logs server | grep -i "email\|smtp"
@@ -670,7 +687,7 @@ docker compose restart server
 # From inside server container
 docker compose exec server sh
 cd /app/server
-node -e "require('dotenv').config(); console.log(process.env.EMAIL_USER_FAU);"
+node -e "require('dotenv').config(); console.log(process.env.EMAIL_SMTP_USER);"
 ```
 
 ### Frontend Not Loading

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       CLIENT_URL: ${CLIENT_URL}
       DB_PATH: ${DB_PATH}
       JWT_SECRET: ${JWT_SECRET}
-      EMAIL_USER_FAU: ${EMAIL_USER_FAU}
-      EMAIL_PASS_FAU: ${EMAIL_PASS_FAU}
+      EMAIL_SMTP_USER: ${EMAIL_SMTP_USER}
+      EMAIL_SMTP_PASS: ${EMAIL_SMTP_PASS}
     volumes:
       - happy-go-lucky-db:/app/server/data
     restart: unless-stopped

--- a/server/src/Config/email.ts
+++ b/server/src/Config/email.ts
@@ -1,15 +1,18 @@
 /**
  * Email configuration settings.
+ * Values can be overridden by environment variables.
  */
 
 export const EMAIL_CONFIG = {
   sender: {
-    name: "Happy Go Lucky",
-    address: "dirk.riehle@fau.de"
+    name: process.env.EMAIL_FROM_NAME || "Happy Go Lucky",
+    address: process.env.EMAIL_FROM_ADDRESS || "dirk.riehle@fau.de"
   },
   smtp: {
-    host: "smtp-auth.fau.de",
-    port: 465,
-    secure: true
+    host: process.env.EMAIL_SMTP_HOST || "smtp-auth.fau.de",
+    port: parseInt(process.env.EMAIL_SMTP_PORT || "465", 10),
+    secure: process.env.EMAIL_SMTP_SECURE
+      ? process.env.EMAIL_SMTP_SECURE.toLowerCase() === "true"
+      : true
   }
 };

--- a/server/src/Services/SmtpEmailService.ts
+++ b/server/src/Services/SmtpEmailService.ts
@@ -32,8 +32,8 @@ export class SmtpEmailService implements IEmailService {
       port: this.smtpPort,
       secure: this.smtpSecure,
       auth: {
-        user: process.env.EMAIL_USER_FAU,
-        pass: process.env.EMAIL_PASS_FAU,
+        user: process.env.EMAIL_SMTP_USER,
+        pass: process.env.EMAIL_SMTP_PASS,
       },
     });
 

--- a/server/src/createApp.ts
+++ b/server/src/createApp.ts
@@ -34,7 +34,7 @@ export function createApp(db: Database): Application {
 
   if (process.env.NODE_ENV === 'production') {
     // Production: use SMTP if credentials available, otherwise fallback to local MTA
-    if (process.env.EMAIL_USER_FAU && process.env.EMAIL_PASS_FAU) {
+    if (process.env.EMAIL_SMTP_USER && process.env.EMAIL_SMTP_PASS) {
       emailService = new SmtpEmailService(
         EMAIL_CONFIG.sender.name,
         EMAIL_CONFIG.sender.address,


### PR DESCRIPTION
## Summary
- Rename production SMTP credential env vars from `EMAIL_USER_FAU`/`EMAIL_PASS_FAU` to provider-neutral `EMAIL_SMTP_USER`/`EMAIL_SMTP_PASS` across backend wiring and compose config.
- Keep `server/src/Config/email.ts` as the central email config module and add env overrides for sender and SMTP host/port/secure with safe default behavior.
- Update `.env.example` and `DEPLOYMENT.md` to document FAU and Gmail (app password) setup and remove stale references to old env vars.
